### PR TITLE
Engine: T-CACHE-EVICTION — eviction mechanism under libtorrent 2.0.12 (A23)

### DIFF
--- a/.claude/specs/00-addendum.md
+++ b/.claude/specs/00-addendum.md
@@ -334,17 +334,39 @@ Separately, while writing the workflow into spec 06 rev 2 (per A18), two things 
 
 **Affected specs:** `02-stream-health.md` § Tier semantics, `04-piece-planner.md` § Tick.
 
+## A23 — libtorrent 2.0.12 eviction API constraint and chosen mechanism
+
+**Context:** Spec 05 rev 2 § Piece eviction mechanism described the primitive as "set priority to 0, truncate regions where possible, or mark them for future overwrite, update the in-memory view." This was hand-wavy because the actual libtorrent API surface had not been verified. Investigation on 2026-04-16 (`docs/libtorrent-eviction-notes.md`) confirmed:
+
+- `torrent_handle::clear_piece` does NOT exist in libtorrent 2.0.12 (our pinned version). It is declared only on the internal `disk_interface` and is called by libtorrent when a piece fails its hash check.
+- Setting `piece_priority(idx, 0)` does not reclaim disk or update the have-bitmap for pieces already downloaded.
+- `ftruncate()` reduces the file on disk but libtorrent does not re-check, so the have-bitmap goes out of sync with reality.
+
+**Decision (v1):** Eviction is implemented in two tiers.
+
+1. **Hot path (per piece, surgical):** `add_piece(idx, 256 KB of zeros, overwrite_existing)` → wait for `hash_failed_alert` → `fcntl(F_PUNCHHOLE)` over the piece-aligned byte range. The intentional hash failure invokes libtorrent's internal `async_clear_piece` and removes the piece from the have-bitmap. The punch reclaims APFS blocks that the zero write re-allocated.
+2. **Fallback (bulk, idle):** `force_recheck()` — only for idle-time reconciliation and recovery if the add_piece trick stops working.
+
+**Risk:** the hot path trades on an implementation detail (add_piece writes its buffer to disk before hashing). If libtorrent ever short-circuits this, we fall back to `force_recheck`. The fallback is already in the bridge surface for this reason.
+
+**Affected files:**
+- `05-cache-policy.md` § Piece eviction mechanism (rewritten — see Rev 3 block).
+- `TorrentBridge.h/.mm` — two new methods: `forceRecheck(torrentID:)` and `addPiece(torrentID:, piece:, data:, overwriteExisting:)`.
+- `EngineService/Cache/CacheEvictionProbe.swift` — revised to test both mechanisms head-to-head.
+- `TASKS.md` T-CACHE-EVICTION — status and probe plan updated.
+
 ## Summary of file changes in this revision
 
 (extends earlier summaries)
 
-- `00-addendum.md` — A16–A19 appended in earlier revision; A20–A22 appended from Phase 1 review.
+- `00-addendum.md` — A16–A19 appended in earlier revision; A20–A22 appended from Phase 1 review; A23 appended from 2026-04-16 API surface investigation.
 - `06-brand.md` — rev 3: § Asset specifications and § Tahoe icon workflow rewritten around the Liquid Glass prep package. Layer model corrected (background + up to 4 foreground groups). `.icon` placement corrected to `App/AppIcon.icon` (sibling of Assets.xcassets, not nested). Step-by-step Icon Composer workflow added. (A19.) Rev 2 introduced Tahoe targeting (A18); rev 1 was the initial brand spec.
 - `07-product-surface.md` — authoritative product surface spec for catalogue, sync, providers, etc. (A17.)
 - `08-issue-workflow.md` — GitHub issue/branch/PR conventions. (A17.)
 - `09-platform-tahoe.md` — authoritative platform spec: macOS 26 deployment target, SDK 26, Apple silicon priority, Liquid Glass adoption stance. § Icon format updated for corrected `.icon` placement. (A18, A19.)
 - All files mentioning project name — `PopcornMac` → `ButterBar`, `popcornmac` → `butterbar`.
 - `02-stream-health.md` — revision bumped; UI rendering contract now points at `06-brand.md` for tier colours.
+- `05-cache-policy.md` — rev 3: § Piece eviction mechanism rewritten with concrete 2.0.12 API surface (add_piece/hash-fail primary + force_recheck fallback). (A23.)
 - `CLAUDE.md` — tagline mentions Tahoe; reading order includes specs 09; project layout updated to show `App/AppIcon.icon` at sibling level and top-level `icons/` (with `ButterBar-LiquidGlass-prep/` subfolder). (A18, A19.)
 - `.claude/README.md` — directory listing updated.
 - `TASKS.md` — `T-REPO-INIT` and `T-BRAND-ASSETS` rewritten for the Liquid Glass prep workflow. T-REPO-INIT places source material; T-BRAND-ASSETS runs Icon Composer. (A18, A19.)

--- a/.claude/specs/05-cache-policy.md
+++ b/.claude/specs/05-cache-policy.md
@@ -1,6 +1,6 @@
 # 05 — Cache Policy
 
-> **Revision 2** — resume offset weakened to byte-last-served (addendum A6, no byte→time map in v1); `settings` and `pinned_files` table schemas added (addendum A7). Baseline revision was rev 1.
+> **Revision 3** — § Piece eviction mechanism rewritten around the libtorrent 2.0.12 public API (addendum A23). Rev 2 weakened resume offset to byte-last-served (A6) and added `settings` + `pinned_files` schemas (A7).
 
 Cache eviction is piece-granular, not file-granular. The unit of value is "pieces the user is likely to need next," not "whole torrents."
 
@@ -42,13 +42,35 @@ At no point does eviction touch a pinned piece.
 
 ## Piece eviction mechanism
 
-libtorrent doesn't have a direct "delete piece" API, but it does have per-piece priority. Eviction works as:
+Per addendum A23. libtorrent 2.0.12's public `torrent_handle` API exposes `force_recheck()` (whole-torrent), `piece_priority()` (gating only, no reconciliation), and `add_piece(..., overwrite_existing)` (per-piece write + hash check). There is no public `clear_piece`. The eviction primitive is built from these.
 
-1. Set priority of target pieces to `0` (do not download).
-2. Call libtorrent's file-level API to truncate regions where possible, or mark them for future overwrite.
-3. Update in-memory `havePieces()` view accordingly so the planner sees the eviction immediately.
+### Hot path — per-piece, surgical
 
-Note: libtorrent may retain some piece data in its buffer cache temporarily. That's fine — the accounting is based on our view of the sparse file, not libtorrent's internal buffers.
+For each piece selected for eviction by the ordering rules above:
+
+1. `TorrentBridge.addPiece(torrentID:, piece: idx, data: <256 KB of zeros>, overwriteExisting: true)`.
+2. Await the `hash_failed_alert` for `idx`. On receipt, libtorrent has internally called `async_clear_piece` and removed `idx` from the have-bitmap.
+3. `fcntl(fd, F_PUNCHHOLE, {offset: pieceStartInFile, length: pieceLength})` on the sparse file to reclaim the APFS blocks that the zero write just re-allocated. `pieceLength` is already an integer multiple of 4 KiB (the APFS allocation unit) for all common torrent piece sizes; no further alignment is required.
+4. Subsequent access under `piece_priority ≥ 1` triggers re-fetch normally.
+
+The punch comes *after* the alert. add_piece writes its buffer to disk before hashing — punching before would be pointless because the zeros would re-fill the hole.
+
+### Fallback — bulk reconciliation
+
+`TorrentBridge.forceRecheck(torrentID:)` is invoked only in two cases:
+
+- **Idle-time reconciliation.** On engine shutdown, or after a batch of evictions, the planner may schedule a recheck to re-sync the have-bitmap with disk across the whole torrent. Runs only while no stream is active.
+- **Recovery.** If `hash_failed_alert` stops arriving after `addPiece(zeros, overwrite)` — e.g., a future libtorrent optimises the write-then-verify path — `CacheManager` falls back to a force-recheck of the affected torrent and logs a one-shot warning.
+
+`force_recheck` is O(on-disk bytes) and pauses peers during the check. It is never used on the streaming hot path.
+
+### In-memory view
+
+After eviction, the in-memory `havePieces()` projection is refreshed by the planner's next tick. The hash_failed_alert also drives an immediate `AlertDispatcher` update so the planner sees the eviction without waiting for the next poll.
+
+### Budget accounting
+
+`CacheManager` tracks `usedBytes` as the sum of on-disk allocated bytes for every sparse file it manages, sampled from `stat().st_blocks * 512` after each eviction batch. Per-piece accounting is not maintained — libtorrent's buffer cache and APFS block-granularity rounding make per-piece byte counts unreliable. The budget is enforced against the aggregate.
 
 ## Disk pressure signalling
 
@@ -108,7 +130,7 @@ CREATE TABLE settings (
 
 - Decide which torrents to add or remove.
 - Serve bytes.
-- Talk to libtorrent for anything other than piece priorities and file truncation.
+- Talk to libtorrent for anything other than piece priorities, add_piece, and force_recheck (see § Piece eviction mechanism).
 - Make UI decisions about "are you sure?" prompts — it just reports pressure.
 
 ## Test obligations
@@ -117,3 +139,4 @@ CREATE TABLE settings (
 - Test that pinned pieces are never selected, regardless of LRU position.
 - Test that crossing thresholds emits exactly one `DiskPressureDTO` per crossing (not a storm).
 - Test resume offset restoration across engine restarts.
+- Test the eviction primitive: addPiece+punch cycle produces hash_failed_alert, removes the piece from havePieces, reduces on-disk bytes by one piece length. Covered by the revised `--cache-eviction-probe` run plus unit tests against a test double.

--- a/.claude/tasks/TASKS.md
+++ b/.claude/tasks/TASKS.md
@@ -268,7 +268,7 @@ Wire `CacheManager` to the GRDB models created in `T-STORE-SCHEMA`. Implemented 
 **Depends on:** `T-STORE-SCHEMA`.
 **Acceptance:** Unit tests that exercise the read/write helpers and verify the in-memory pinned set is rebuilt correctly after a simulated engine restart.
 
-### T-CACHE-EVICTION `[sonnet]` · BLOCKED: probe accepts real magnet, awaiting user run with real torrent · SPIKE
+### T-CACHE-EVICTION `[sonnet]` · IN-PROGRESS: mechanism decided (A23), bridge + probe rewrite landing on `engine/T-CACHE-EVICTION` · SPIKE
 Spike and then implement `CacheManager` with the eviction ordering from `05-cache-policy.md`. Unit tests with synthetic sparse-file state.
 
 **Probe interface (2026-04-16 rewrite):** Original probe generated synthetic 256 KB content via `createTestTorrent`, which is broken in the sandbox. Rewritten to accept a real magnet link (or `.torrent` path) so observations come from real libtorrent behaviour on real content:
@@ -291,7 +291,11 @@ Downloaded content is left in `NSTemporaryDirectory()` for iterative reruns. Pas
 .build/debug/EngineService --cache-eviction-probe 2>&1 | tee docs/libtorrent-eviction-notes.md
 ```
 
-**TorrentBridge gap noted:** `TorrentBridge` exposes `setFilePriority` (file granularity) but NOT `setPiecePriority` (piece granularity). The probe uses file-level priority as the coarsest available lever. If empirical results show that per-piece eviction is required, a `setPiecePriority` method must be added to `TorrentBridge.h/.mm` before step 5.
+**TorrentBridge mechanism (2026-04-16 decision, addendum A23):** libtorrent 2.0.12 does NOT expose `torrent_handle::clear_piece`; `grep` of the Homebrew headers confirmed the method is internal to `disk_interface` only. Eviction is therefore built from two public methods:
+- `addPiece(torrentID:, piece:, data:, overwriteExisting:)` — primary, per-piece. Writing 256 KB of zeros with `overwrite_existing` triggers a hash failure, which causes libtorrent to internally call `async_clear_piece` and remove the piece from the have-bitmap. Paired with a piece-aligned `F_PUNCHHOLE` *after* the `hash_failed_alert` arrives to reclaim APFS blocks.
+- `forceRecheck(torrentID:)` — fallback, whole-torrent. Reserved for idle-time bulk reconciliation and recovery if the add_piece trick ever stops working.
+
+Both methods are being added to `TorrentBridge.h/.mm` on `engine/T-CACHE-EVICTION`. The revised probe exercises both in a single run so observations come from the real library.
 
 **Depends on:** `T-CACHE-SCHEMA`, `T-BRIDGE-API` (need real libtorrent to probe).
 **Acceptance:** Probe notes committed, CacheManager implemented against observed behaviour, unit tests green, spec 05 updated with concrete mechanism (remove the "where possible / mark for future overwrite" hedge).

--- a/EngineService/Bridge/TorrentBridge.h
+++ b/EngineService/Bridge/TorrentBridge.h
@@ -12,6 +12,7 @@ typedef NS_ERROR_ENUM(TorrentBridgeErrorDomain, TorrentBridgeError) {
     TorrentBridgeErrorFileNotFound     = 3,
     TorrentBridgeErrorReadError        = 4,
     TorrentBridgeErrorMetadataNotReady = 5,
+    TorrentBridgeErrorInvalidArgument  = 6,
 };
 
 /// Narrow ObjC++ wrapper over a single lt::session.
@@ -73,9 +74,19 @@ typedef NS_ERROR_ENUM(TorrentBridgeErrorDomain, TorrentBridgeError) {
 
 /// Requests libtorrent to re-verify the entire torrent against what's on disk.
 /// Equivalent to `lt::torrent_handle::force_recheck()`. This is a heavy operation:
-/// libtorrent will disconnect peers, read every existing file, and re-hash every
-/// piece. Completion is asynchronous — observe via `torrent_checked_alert` or by
-/// polling `statusSnapshot` for the `checkingFiles` state to clear.
+/// libtorrent will disconnect all peers, read every existing file, and re-hash
+/// every piece. Completion is asynchronous — observe via `torrent_checked_alert`
+/// or by polling `statusSnapshot` for the `checkingFiles` state to clear.
+///
+/// Side effects (per libtorrent torrent_handle.hpp:664-672):
+///   - Resume-data state is reset; libtorrent treats the torrent as having no
+///     resume data after the call.
+///   - All peers are disconnected before checking begins.
+///   - The torrent stops announcing to the tracker during the check.
+///   - The torrent is placed at the end of the session queue (last queue position).
+///
+/// Calling while the torrent is already in `checkingFiles` or `checkingResumeData`
+/// state may restart the check; exact behaviour is libtorrent-internal.
 ///
 /// Used as the cache-eviction fallback path (see `05-cache-policy.md` § Fallback).
 /// Not intended for streaming-hot-path use.
@@ -88,13 +99,24 @@ typedef NS_ERROR_ENUM(TorrentBridgeErrorDomain, TorrentBridgeError) {
 /// The hash check result arrives asynchronously via `piece_finished_alert` (pass)
 /// or `hash_failed_alert` (fail).
 ///
-/// Primary use: the cache-eviction hot path per spec 05 rev 3. Passing 256 KB of
-/// zeros with `overwriteExisting: YES` triggers a deliberate hash failure which
-/// libtorrent resolves by internally calling `async_clear_piece`, removing the
-/// piece from the have-bitmap.
+/// Primary use: the cache-eviction hot path per spec 05 rev 3. Passing zeros with
+/// `overwriteExisting: YES` triggers a deliberate hash failure which libtorrent
+/// resolves by internally calling `async_clear_piece`, removing the piece from
+/// the have-bitmap.
 ///
-/// `data` must be exactly `pieceLength` bytes (see `pieceLength:`). Passing the
-/// wrong length is caller error; libtorrent's behaviour is undefined.
+/// `data` length must equal `piece_size(piece)` for the target piece — NOT
+/// uniformly `pieceLength:`, because the last piece of a torrent is typically
+/// shorter. The bridge validates this and returns `TorrentBridgeErrorInvalidArgument`
+/// on mismatch.
+///
+/// Caller constraints:
+///   - Calling while the torrent is in `checkingFiles` state is unsupported by
+///     libtorrent (per torrent_handle.hpp:286-287); the caller (CacheManager) must
+///     ensure this state is not active.
+///   - With `overwriteExisting: YES` on a piece that is actively being downloaded
+///     from peers, libtorrent docs (torrent_handle.hpp:266-270) note that in-flight
+///     blocks may not be replaced. For the eviction use case this is not a concern
+///     (we target fully-downloaded pieces), but direct callers should be aware.
 - (BOOL)addPiece:(NSString *)torrentID
            piece:(int)piece
             data:(NSData *)data
@@ -133,7 +155,8 @@ overwriteExisting:(BOOL)overwriteExisting
 // MARK: - Alert subscription
 
 /// Registers a callback that is invoked (on an internal serial queue) for every alert.
-/// Alert dict: @{ @"type": NSString, @"torrentID": NSString (if applicable), @"message": NSString }
+/// Alert dict: @{ @"type": NSString, @"torrentID": NSString (if applicable), @"message": NSString,
+///                @"pieceIndex": NSNumber (int, only for hash_failed_alert and piece_finished_alert) }
 /// Pass nil to clear the callback.
 - (void)subscribeAlerts:(nullable void (^)(NSDictionary *alert))callback;
 

--- a/EngineService/Bridge/TorrentBridge.h
+++ b/EngineService/Bridge/TorrentBridge.h
@@ -71,6 +71,36 @@ typedef NS_ERROR_ENUM(TorrentBridgeErrorDomain, TorrentBridgeError) {
                exceptPieces:(NSArray<NSNumber *> *)exceptPieces
                       error:(NSError **)error;
 
+/// Requests libtorrent to re-verify the entire torrent against what's on disk.
+/// Equivalent to `lt::torrent_handle::force_recheck()`. This is a heavy operation:
+/// libtorrent will disconnect peers, read every existing file, and re-hash every
+/// piece. Completion is asynchronous — observe via `torrent_checked_alert` or by
+/// polling `statusSnapshot` for the `checkingFiles` state to clear.
+///
+/// Used as the cache-eviction fallback path (see `05-cache-policy.md` § Fallback).
+/// Not intended for streaming-hot-path use.
+- (BOOL)forceRecheck:(NSString *)torrentID
+               error:(NSError **)error;
+
+/// Writes `data` to the torrent's storage as piece `piece` and schedules a hash
+/// check. If `overwriteExisting` is YES, libtorrent will overwrite any bytes
+/// already on disk for that piece (mapped to `add_piece_flags_t::overwrite_existing`).
+/// The hash check result arrives asynchronously via `piece_finished_alert` (pass)
+/// or `hash_failed_alert` (fail).
+///
+/// Primary use: the cache-eviction hot path per spec 05 rev 3. Passing 256 KB of
+/// zeros with `overwriteExisting: YES` triggers a deliberate hash failure which
+/// libtorrent resolves by internally calling `async_clear_piece`, removing the
+/// piece from the have-bitmap.
+///
+/// `data` must be exactly `pieceLength` bytes (see `pieceLength:`). Passing the
+/// wrong length is caller error; libtorrent's behaviour is undefined.
+- (BOOL)addPiece:(NSString *)torrentID
+           piece:(int)piece
+            data:(NSData *)data
+overwriteExisting:(BOOL)overwriteExisting
+           error:(NSError **)error;
+
 // MARK: - Status
 
 /// Returns a snapshot of the torrent's current status.

--- a/EngineService/Bridge/TorrentBridge.mm
+++ b/EngineService/Bridge/TorrentBridge.mm
@@ -358,6 +358,66 @@ struct BridgeState {
     return ok;
 }
 
+- (BOOL)forceRecheck:(NSString *)torrentID
+               error:(NSError **)error {
+    __block BOOL ok = NO;
+    __block NSError *opError = nil;
+
+    dispatch_sync(_queue, ^{
+        lt::torrent_handle h;
+        if (![self _handle:torrentID into:&h error:&opError]) return;
+        h.force_recheck();
+        ok = YES;
+    });
+
+    if (error) *error = opError;
+    return ok;
+}
+
+- (BOOL)addPiece:(NSString *)torrentID
+           piece:(int)piece
+            data:(NSData *)data
+overwriteExisting:(BOOL)overwriteExisting
+           error:(NSError **)error {
+    __block BOOL ok = NO;
+    __block NSError *opError = nil;
+
+    dispatch_sync(_queue, ^{
+        lt::torrent_handle h;
+        if (![self _handle:torrentID into:&h error:&opError]) return;
+
+        auto ti = h.torrent_file();
+        if (!ti) { opError = [self _metadataNotReadyError]; return; }
+
+        if (piece < 0 || piece >= ti->num_pieces()) {
+            opError = [NSError errorWithDomain:TorrentBridgeErrorDomain
+                                          code:TorrentBridgeErrorFileNotFound
+                                      userInfo:@{
+                NSLocalizedDescriptionKey: [NSString stringWithFormat:
+                    @"Piece index %d out of range (num_pieces=%d)",
+                    piece, ti->num_pieces()]
+            }];
+            return;
+        }
+
+        // libtorrent's std::vector overload is async (non-blocking). Copy the
+        // bytes once here; libtorrent owns the vector from this point.
+        std::vector<char> buf(
+            static_cast<const char *>(data.bytes),
+            static_cast<const char *>(data.bytes) + data.length
+        );
+
+        lt::add_piece_flags_t flags = {};
+        if (overwriteExisting) flags |= lt::torrent_handle::overwrite_existing;
+
+        h.add_piece(lt::piece_index_t(piece), std::move(buf), flags);
+        ok = YES;
+    });
+
+    if (error) *error = opError;
+    return ok;
+}
+
 // MARK: - Status
 
 - (nullable NSDictionary *)statusSnapshot:(NSString *)torrentID error:(NSError **)error {
@@ -554,6 +614,14 @@ struct BridgeState {
                     }
                 }
             }
+        }
+
+        // Attach pieceIndex for hash_failed_alert and piece_finished_alert so
+        // probes and eviction logic can identify which piece was affected.
+        if (auto *hfa = lt::alert_cast<lt::hash_failed_alert>(a)) {
+            dict[@"pieceIndex"] = @((int)hfa->piece_index);
+        } else if (auto *pfa = lt::alert_cast<lt::piece_finished_alert>(a)) {
+            dict[@"pieceIndex"] = @((int)pfa->piece_index);
         }
 
         self->_alertCallback([dict copy]);

--- a/EngineService/Bridge/TorrentBridge.mm
+++ b/EngineService/Bridge/TorrentBridge.mm
@@ -400,6 +400,21 @@ overwriteExisting:(BOOL)overwriteExisting
             return;
         }
 
+        // Validate data length against the exact piece size. The last piece is
+        // typically shorter than the rest; libtorrent's behaviour is undefined if
+        // the buffer length is wrong (torrent_info::piece_size is authoritative).
+        int expectedSize = ti->piece_size(lt::piece_index_t(piece));
+        if ((int)data.length != expectedSize) {
+            opError = [NSError errorWithDomain:TorrentBridgeErrorDomain
+                                          code:TorrentBridgeErrorInvalidArgument
+                                      userInfo:@{
+                NSLocalizedDescriptionKey: [NSString stringWithFormat:
+                    @"addPiece data length %lu does not match piece size %d for piece %d",
+                    (unsigned long)data.length, expectedSize, piece]
+            }];
+            return;
+        }
+
         // libtorrent's std::vector overload is async (non-blocking). Copy the
         // bytes once here; libtorrent owns the vector from this point.
         std::vector<char> buf(

--- a/EngineService/Cache/CacheEvictionProbe.swift
+++ b/EngineService/Cache/CacheEvictionProbe.swift
@@ -340,109 +340,318 @@ private func runCacheEvictionProbe(probeArgs: ProbeArgs) -> [String] {
         probeError("Probe B: havePieces failed: \(error)")
     }
 
-    // MARK: - Probe C: explicit sparse-hole punch attempt via F_PUNCHHOLE
+    // MARK: - Probe C: two-mechanism eviction test (addPiece+punch and force_recheck)
+
+    // Alert collectors for C1. The alert callback runs on bridge's internal queue;
+    // reads happen on this thread. Use NSLock for thread-safety.
+    let alertLock = NSLock()
+    var hashFailedPieces: Set<Int> = []
+    var pieceFinishedPieces: Set<Int> = []
+
+    bridge.subscribeAlerts { alert in
+        let type = alert["type"] as? String ?? "?"
+        let msg  = alert["message"] as? String ?? ""
+        NSLog("[CacheEvictionProbe:alert] type=%@ msg=%@", type, msg)
+
+        if let idx = (alert["pieceIndex"] as? NSNumber)?.intValue {
+            alertLock.lock()
+            if type == "hash_failed_alert" {
+                hashFailedPieces.insert(idx)
+            } else if type == "piece_finished_alert" {
+                pieceFinishedPieces.insert(idx)
+            }
+            alertLock.unlock()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Probe C1: addPiece(zeros, overwrite_existing) → hash_failed_alert → punch
+    // -------------------------------------------------------------------------
 
     note("")
-    note("--- Probe C: attempt F_PUNCHHOLE on file region ---")
-    note("  Hypothesis: libtorrent does not truncate/sparsify on priority=0;")
-    note("  the app must call F_PUNCHHOLE itself to reclaim APFS disk space.")
-    if let fp = downloadedFilePath {
-        let fd = open(fp, O_RDWR)
-        if fd < 0 {
-            let errStr = String(cString: strerror(errno))
-            probeError("Probe C: open(\(fp)) failed: \(errStr) (errno=\(errno))")
-        } else {
-            var preStat = stat()
-            stat(fp, &preStat)
-            let fileSize = Int64(preStat.st_size)
-            note("Probe C: file size before punch = \(fileSize) bytes")
+    note("--- Probe C1: addPiece(zeros, overwrite_existing) + F_PUNCHHOLE ---")
+    note("  Goal: confirm zeros trigger hash_failed_alert, piece leaves havePieces, punch reclaims blocks.")
 
-            // Punch from byte 0 to half the file.
-            let punchLen = fileSize / 2
-            let success = punchHole(fd: fd, offset: 0, length: punchLen)
-            if success {
-                note("Probe C: F_PUNCHHOLE succeeded for [0, \(punchLen))")
-            } else {
-                let errStr = String(cString: strerror(errno))
-                note("Probe C: F_PUNCHHOLE failed: \(errStr) (errno=\(errno))")
-                note("  On HFS+: ENOTSUP is expected (no sparse file support).")
-                note("  On APFS: success is expected.")
+    var c1ClearedPiece: Int? = nil
+
+    // All C1 logic in a labeled do-block so we can break out early on skip conditions.
+    probeC1: do {
+        var fileStart: Int64 = 0
+        var fileEnd: Int64 = 0
+        do {
+            try bridge.fileByteRange(torrentID, fileIndex: Int32(targetFileIndex),
+                                     start: &fileStart, end: &fileEnd)
+        } catch {
+            probeError("Probe C1: fileByteRange failed: \(error)")
+            break probeC1
+        }
+
+        let havePiecesBefore: [NSNumber]
+        do {
+            havePiecesBefore = try bridge.havePieces(torrentID)
+        } catch {
+            probeError("Probe C1: havePieces failed: \(error)")
+            break probeC1
+        }
+        let haveSet = Set(havePiecesBefore.map { $0.intValue })
+
+        // firstFullPiece = ceil(fileStart / pieceLen), lastFullPieceExcl = floor(fileEnd / pieceLen)
+        let firstFull = Int((fileStart + pieceLen - 1) / pieceLen)
+        let lastFull  = Int(fileEnd / pieceLen)   // exclusive upper bound
+
+        note("Probe C1: file byte range [\(fileStart), \(fileEnd)), pieceLen=\(pieceLen)")
+        note("Probe C1: full-piece range within file: [\(firstFull), \(lastFull))")
+
+        // Pick first downloaded piece in the full-piece range.
+        var targetPiece: Int? = nil
+        for p in firstFull..<lastFull {
+            if haveSet.contains(p) {
+                targetPiece = p
+                break
             }
-            close(fd)
+        }
 
-            if let s = statFile(fp) {
-                note("Probe C: after F_PUNCHHOLE — file size=\(s.apparentSize), on-disk=\(s.onDiskBytes)")
-                if s.onDiskBytes < preStat.st_blocks * 512 {
-                    note("Probe C: RESULT: disk blocks decreased — APFS sparse region created.")
+        guard let tp = targetPiece else {
+            note("Probe C1: SKIPPED — no downloaded piece fully inside target file (firstFull=\(firstFull), lastFull=\(lastFull), haveSet size=\(haveSet.count))")
+            note("  This can happen if < 1 full piece is available for the target file.")
+            note("Probe C1: RESULT: SKIPPED")
+            break probeC1
+        }
+
+        note("Probe C1: target piece = \(tp)")
+        note("Probe C1: pre-check havePieces includes piece \(tp): \(haveSet.contains(tp))")
+
+        // Pre-stat the file.
+        var preOnDisk: Int64 = 0
+        if let fp = downloadedFilePath, let s = statFile(fp) {
+            preOnDisk = s.onDiskBytes
+            note("Probe C1: file on-disk bytes before = \(s.onDiskBytes)")
+        }
+
+        // Build zeros buffer sized to the actual piece length (last piece may differ,
+        // but we only pick full pieces so pieceLen is correct here).
+        let zeros = Data(count: Int(pieceLen))
+
+        // Call addPiece with overwrite_existing.
+        do {
+            try bridge.addPiece(torrentID, piece: Int32(tp), data: zeros, overwriteExisting: true)
+            note("Probe C1: addPiece(piece:\(tp), zeros, overwrite_existing) sent")
+        } catch {
+            probeError("Probe C1: addPiece failed: \(error)")
+            // Continue — we still want to punch and observe.
+        }
+
+        // Poll for hash_failed_alert for up to 15s.
+        note("Probe C1: polling for hash_failed_alert (pieceIndex=\(tp)) for up to 15s...")
+        let c1Deadline = Date().addingTimeInterval(15)
+        var lastC1Log = Date()
+        var gotHashFailed = false
+        var gotPieceFinished = false
+        while Date() < c1Deadline {
+            alertLock.lock()
+            gotHashFailed    = hashFailedPieces.contains(tp)
+            gotPieceFinished = pieceFinishedPieces.contains(tp)
+            alertLock.unlock()
+
+            if gotHashFailed || gotPieceFinished { break }
+
+            if Date().timeIntervalSince(lastC1Log) >= 2 {
+                alertLock.lock()
+                let hf = hashFailedPieces
+                let pf = pieceFinishedPieces
+                alertLock.unlock()
+                note("  Probe C1: still waiting... hashFailed=\(hf) pieceDone=\(pf)")
+                lastC1Log = Date()
+            }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+
+        if gotHashFailed {
+            note("Probe C1: hash_failed_alert received for piece \(tp) — as expected.")
+        } else if gotPieceFinished {
+            note("Probe C1: UNEXPECTED — piece_finished_alert received (zeros matched hash!). Piece NOT evicted.")
+        } else {
+            note("Probe C1: NEGATIVE RESULT — neither hash_failed_alert nor piece_finished_alert arrived within 15s.")
+            note("  Possible causes: alert mask, libtorrent version behaviour, or torrent not in downloading/finished state.")
+        }
+
+        // Check havePieces after hash failure.
+        let havePiecesAfterAdd = (try? bridge.havePieces(torrentID)) ?? []
+        let haveSetAfter = Set(havePiecesAfterAdd.map { $0.intValue })
+        let pieceCleared = !haveSetAfter.contains(tp)
+        note("Probe C1: after addPiece — havePieces contains piece \(tp): \(!pieceCleared)")
+
+        if gotHashFailed && pieceCleared {
+            note("Probe C1: piece \(tp) confirmed removed from have-bitmap after hash failure.")
+            c1ClearedPiece = tp
+        } else if gotHashFailed && !pieceCleared {
+            note("Probe C1: WARNING — hash_failed_alert arrived but piece \(tp) still in have-bitmap. libtorrent may not have updated yet.")
+            // Give it another 2s.
+            Thread.sleep(forTimeInterval: 2)
+            let havePiecesRetry = (try? bridge.havePieces(torrentID)) ?? []
+            if !Set(havePiecesRetry.map { $0.intValue }).contains(tp) {
+                note("Probe C1: piece \(tp) confirmed cleared after additional 2s wait.")
+                c1ClearedPiece = tp
+            } else {
+                note("Probe C1: piece \(tp) still in have-bitmap after extra wait.")
+            }
+        }
+
+        // Punch the hole regardless (to test filesystem behaviour even if bitmap isn't updated).
+        if let fp = downloadedFilePath {
+            let pieceOffsetInFile = Int64(tp) * pieceLen - fileStart
+            let fd = open(fp, O_RDWR)
+            if fd < 0 {
+                let errStr = String(cString: strerror(errno))
+                probeError("Probe C1: open for punch failed: \(errStr) (errno=\(errno))")
+            } else {
+                note("Probe C1: punching hole at file-relative offset \(pieceOffsetInFile), length \(pieceLen)")
+                let punchOK = punchHole(fd: fd, offset: pieceOffsetInFile, length: pieceLen)
+                if punchOK {
+                    note("Probe C1: F_PUNCHHOLE succeeded.")
                 } else {
-                    note("Probe C: RESULT: disk blocks unchanged — punch had no effect.")
+                    let errStr = String(cString: strerror(errno))
+                    note("Probe C1: F_PUNCHHOLE failed: \(errStr) (errno=\(errno))")
+                    note("  On HFS+: ENOTSUP is expected. On APFS: success expected.")
+                }
+                close(fd)
+
+                if let s = statFile(fp) {
+                    let delta = preOnDisk - s.onDiskBytes
+                    note("Probe C1: after punch — on-disk bytes = \(s.onDiskBytes) (delta = \(delta))")
+                    let slack: Int64 = 65536  // APFS block-rounding allowance
+                    if delta >= pieceLen - slack {
+                        note("Probe C1: RESULT: on-disk bytes decreased by ~pieceLen — APFS sparse region created.")
+                    } else if delta > 0 {
+                        note("Probe C1: RESULT: on-disk bytes decreased by \(delta), less than pieceLen (\(pieceLen)). Partial effect.")
+                    } else {
+                        note("Probe C1: RESULT: on-disk bytes unchanged — punch had no effect (HFS+ or already sparse).")
+                    }
                 }
             }
-
-            do {
-                let pieces = try bridge.havePieces(torrentID)
-                note("Probe C: havePieces count=\(pieces.count) after punch (libtorrent's view unchanged?)")
-            } catch {
-                probeError("Probe C: havePieces failed: \(error)")
-            }
-
-            // Try to read from the punched region via TorrentBridge.
-            do {
-                let data = try bridge.readBytes(torrentID, fileIndex: Int32(targetFileIndex), offset: 0, length: 4096)
-                note("Probe C: readBytes from punched region returned \(data.count) bytes")
-                note("  (non-nil means libtorrent served bytes; are they zeros from the hole?)")
-                let allZero = data.allSatisfy { $0 == 0 }
-                note("  data is all-zero: \(allZero)")
-            } catch {
-                note("Probe C: readBytes from punched region threw: \(error)")
-                note("  (error is expected if libtorrent detects the missing data)")
-            }
         }
-    } else {
-        note("Probe C: SKIPPED — no file path resolved")
+    } // end probeC1
+
+    // -------------------------------------------------------------------------
+    // Probe C2: force_recheck
+    // -------------------------------------------------------------------------
+
+    note("")
+    note("--- Probe C2: force_recheck() — validate fallback re-verification mechanism ---")
+    note("  Goal: confirm force_recheck completes and produces a coherent havePieces bitmap.")
+
+    let havePiecesBeforeRecheck = (try? bridge.havePieces(torrentID))?.count ?? 0
+    note("Probe C2: havePieces count before force_recheck = \(havePiecesBeforeRecheck)")
+
+    do {
+        try bridge.forceRecheck(torrentID)
+        note("Probe C2: forceRecheck() called — libtorrent will disconnect peers and re-hash all pieces.")
+    } catch {
+        probeError("Probe C2: forceRecheck failed: \(error)")
     }
 
-    // Truncate variant.
+    // Poll for state to transition through checkingFiles/checkingResumeData, up to 90s.
+    note("Probe C2: polling for checking state to clear (up to 90s)...")
+    let c2Deadline = Date().addingTimeInterval(90)
+    var lastC2Log = Date()
+    var lastState = ""
+    var checkingStarted = false
+    var checkingCleared = false
+
+    while Date() < c2Deadline {
+        if let snap = try? bridge.statusSnapshot(torrentID) {
+            let state = snap["state"] as? String ?? "unknown"
+            if state != lastState {
+                note("  Probe C2: state transition → \(state)")
+                lastState = state
+            }
+            if state == "checkingFiles" || state == "checkingResumeData" {
+                checkingStarted = true
+            }
+            if checkingStarted && state != "checkingFiles" && state != "checkingResumeData" {
+                checkingCleared = true
+                break
+            }
+        }
+        if Date().timeIntervalSince(lastC2Log) >= 5 {
+            note("  Probe C2: still checking... state=\(lastState)")
+            lastC2Log = Date()
+        }
+        Thread.sleep(forTimeInterval: 0.5)
+    }
+
+    if checkingCleared {
+        note("Probe C2: checking completed. Final state = \(lastState)")
+    } else if checkingStarted {
+        note("Probe C2: checking started but did NOT clear within 90s.")
+    } else {
+        note("Probe C2: checking state was never observed — force_recheck may have completed too quickly or state polling missed it.")
+    }
+
+    let havePiecesAfterRecheck = (try? bridge.havePieces(torrentID))?.count ?? 0
+    let recheckDelta = havePiecesAfterRecheck - havePiecesBeforeRecheck
+    note("Probe C2: havePieces count after recheck = \(havePiecesAfterRecheck) (delta = \(recheckDelta >= 0 ? "+\(recheckDelta)" : "\(recheckDelta)"))")
+    if let cp = c1ClearedPiece {
+        let stillMissing = !((try? bridge.havePieces(torrentID))?.map({ $0.intValue }).contains(cp) ?? false)
+        note("Probe C2: piece \(cp) cleared in C1 — still missing after recheck: \(stillMissing)")
+        note("  Expected: true (punched zeros won't match the piece hash).")
+    }
+    note("Probe C2: RESULT: recheck completed=\(checkingCleared), bitmap delta=\(recheckDelta)")
+
+    // -------------------------------------------------------------------------
+    // Probe C3: priority restore → re-fetch of cleared piece
+    // -------------------------------------------------------------------------
+
     note("")
-    note("Probe C (truncate variant): attempt ftruncate to see libtorrent's reaction")
-    if let fp = downloadedFilePath {
-        var preStat = stat()
-        stat(fp, &preStat)
-        let originalSize = Int64(preStat.st_size)
+    note("--- Probe C3: priority restore → re-fetch of C1-cleared piece ---")
+    note("  Goal: confirm libtorrent re-downloads the piece cleared in C1 after priority=1 is restored.")
 
-        let fd2 = open(fp, O_RDWR)
-        if fd2 >= 0 {
-            if ftruncate(fd2, off_t(originalSize / 2)) == 0 {
-                note("Probe C (truncate): ftruncate to \(originalSize / 2) succeeded")
-            } else {
-                let errStr = String(cString: strerror(errno))
-                note("Probe C (truncate): ftruncate failed: \(errStr) (errno=\(errno))")
-            }
-            close(fd2)
+    if let c3TargetPiece = c1ClearedPiece {
+        do {
+            try bridge.setFilePriority(torrentID, fileIndex: Int32(targetFileIndex), priority: 1)
+            note("Probe C3: setFilePriority(\(targetFileIndex), priority:1) called.")
+        } catch {
+            probeError("Probe C3: setFilePriority failed: \(error)")
+        }
 
-            if let s = statFile(fp) {
-                note("Probe C (truncate): file size=\(s.apparentSize), on-disk=\(s.onDiskBytes)")
-            }
+        note("Probe C3: polling for piece \(c3TargetPiece) to reappear in havePieces (up to 30s)...")
+        let c3Deadline = Date().addingTimeInterval(30)
+        var lastC3Log = Date()
+        var c3Refetched = false
 
-            Thread.sleep(forTimeInterval: 2)
-            do {
-                let pieces = try bridge.havePieces(torrentID)
-                note("Probe C (truncate): havePieces after 2s = \(pieces.count) pieces")
-            } catch {
-                probeError("Probe C (truncate): havePieces failed: \(error)")
+        while Date() < c3Deadline {
+            if let pieces = try? bridge.havePieces(torrentID) {
+                if pieces.map({ $0.intValue }).contains(c3TargetPiece) {
+                    c3Refetched = true
+                    break
+                }
             }
+            if Date().timeIntervalSince(lastC3Log) >= 2 {
+                let count = (try? bridge.havePieces(torrentID))?.count ?? 0
+                note("  Probe C3: still waiting... havePieces count=\(count)")
+                lastC3Log = Date()
+            }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
+        if c3Refetched {
+            note("Probe C3: RESULT: cleared piece \(c3TargetPiece) re-fetched successfully after priority restore.")
         } else {
-            let errStr = String(cString: strerror(errno))
-            probeError("Probe C (truncate): open failed: \(errStr) (errno=\(errno))")
+            note("Probe C3: RESULT: cleared piece \(c3TargetPiece) NOT re-fetched within 30s.")
+            note("  Possible causes: no peers, file priority 0 still set, or libtorrent de-prioritised the piece.")
         }
     } else {
-        note("Probe C (truncate): SKIPPED — no file path")
+        note("Probe C3: SKIPPED — C1 did not clear any pieces.")
     }
 
-    // MARK: - Probe D: restore priority to 1, verify libtorrent re-fetches
+    // MARK: - Probe D: file-level priority restore, re-fetch of entire file
 
     note("")
-    note("--- Probe D: restore file priority to 1, wait for re-fetch ---")
+    note("--- Probe D: file-level priority restore, wait for full re-fetch ---")
+    note("  Tests the whole-file priority-restore pathway (distinct from C3's single-piece test).")
+    note("  If C2 (force_recheck) significantly changed havePieces, Probe D behaviour may differ.")
+    // Priority may already be 1 from C3; set it again to be explicit.
+
     do {
         try bridge.setFilePriority(torrentID, fileIndex: Int32(targetFileIndex), priority: 1)
         note("Probe D: setFilePriority(\(torrentID), fileIndex:\(targetFileIndex), priority:1) succeeded")
@@ -482,12 +691,14 @@ private func runCacheEvictionProbe(probeArgs: ProbeArgs) -> [String] {
     note("Copy all lines above into docs/libtorrent-eviction-notes.md")
     note("")
     note("Key questions to answer from the output:")
-    note("  1. Did setFilePriority(0) change on-disk bytes? (Probe A vs B)")
-    note("  2. Did F_PUNCHHOLE succeed on this filesystem? (Probe C)")
-    note("  3. After punch, did libtorrent's havePieces still show the punched pieces? (Probe C)")
-    note("  4. After ftruncate, did libtorrent automatically re-expand the file? (Probe C truncate)")
-    note("  5. After restoring priority=1, did libtorrent re-fetch the missing pieces? (Probe D)")
-    note("  6. What is the piece length for this torrent? (Setup output)")
+    note("  1. Did setFilePriority(0) alone change on-disk bytes? (Probe A vs B)")
+    note("  2. Did addPiece(zeros, overwrite_existing) produce a hash_failed_alert? (Probe C1)")
+    note("  3. After C1's hash failure, did the targeted piece leave havePieces()? (Probe C1)")
+    note("  4. Did the piece-aligned F_PUNCHHOLE reduce on-disk bytes by roughly pieceLength? (Probe C1)")
+    note("  5. Did force_recheck() complete and produce a coherent havePieces() bitmap? (Probe C2)")
+    note("  6. After C1 + priority restore, did libtorrent re-download the cleared piece? (Probe C3)")
+    note("  7. Does file-level setFilePriority(1) trigger full re-fetch of the file? (Probe D)")
+    note("  8. What is the piece length for this torrent? (Setup output)")
 
     return log
 }

--- a/EngineService/Cache/CacheEvictionProbe.swift
+++ b/EngineService/Cache/CacheEvictionProbe.swift
@@ -348,6 +348,9 @@ private func runCacheEvictionProbe(probeArgs: ProbeArgs) -> [String] {
     var hashFailedPieces: Set<Int> = []
     var pieceFinishedPieces: Set<Int> = []
 
+    // Safe to replace the setup-time alert callback here: TorrentBridge serialises
+    // both subscribeAlerts installation and alert drain on the same internal queue,
+    // so we cannot miss or double-fire an alert during handover.
     bridge.subscribeAlerts { alert in
         let type = alert["type"] as? String ?? "?"
         let msg  = alert["message"] as? String ?? ""
@@ -693,12 +696,13 @@ private func runCacheEvictionProbe(probeArgs: ProbeArgs) -> [String] {
     note("Key questions to answer from the output:")
     note("  1. Did setFilePriority(0) alone change on-disk bytes? (Probe A vs B)")
     note("  2. Did addPiece(zeros, overwrite_existing) produce a hash_failed_alert? (Probe C1)")
-    note("  3. After C1's hash failure, did the targeted piece leave havePieces()? (Probe C1)")
-    note("  4. Did the piece-aligned F_PUNCHHOLE reduce on-disk bytes by roughly pieceLength? (Probe C1)")
-    note("  5. Did force_recheck() complete and produce a coherent havePieces() bitmap? (Probe C2)")
-    note("  6. After C1 + priority restore, did libtorrent re-download the cleared piece? (Probe C3)")
-    note("  7. Does file-level setFilePriority(1) trigger full re-fetch of the file? (Probe D)")
-    note("  8. What is the piece length for this torrent? (Setup output)")
+    note("  3. Was the addPiece path processed at all given the target file's priority=0 set in Probe B, i.e. did the hash check actually run? (Probe C1 — a silent timeout suggests priority=0 blocks addPiece processing.)")
+    note("  4. After C1's hash failure, did the targeted piece leave havePieces()? (Probe C1)")
+    note("  5. Did the piece-aligned F_PUNCHHOLE reduce on-disk bytes by roughly pieceLength? (Probe C1)")
+    note("  6. Did force_recheck() complete and produce a coherent havePieces() bitmap? (Probe C2)")
+    note("  7. After C1 + priority restore, did libtorrent re-download the cleared piece? (Probe C3)")
+    note("  8. Does file-level setFilePriority(1) trigger full re-fetch of the file? (Probe D)")
+    note("  9. What is the piece length for this torrent? (Setup output)")
 
     return log
 }

--- a/docs/libtorrent-eviction-notes.md
+++ b/docs/libtorrent-eviction-notes.md
@@ -1,130 +1,1131 @@
-# libtorrent eviction probe — investigation notes
+2026-04-16 11:27:28.514 EngineService[91780:2327330] [EngineService-main] process starting, args=(
+    "/Users/mattkneale/Library/Developer/Xcode/DerivedData/ButterBar-clpqpoujfzkmtgbmmytkdlluxtie/Build/Products/Debug/EngineService.xpc/Contents/MacOS/EngineService",
+    "--cache-eviction-probe",
+    "magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+)
+2026-04-16 11:27:28.515 EngineService[91780:2327330] [CacheEvictionProbe] === T-CACHE-EVICTION probe starting ===
+2026-04-16 11:27:28.515 EngineService[91780:2327330] [CacheEvictionProbe] Paste all lines below into docs/libtorrent-eviction-notes.md
+2026-04-16 11:27:28.536 EngineService[91780:2327330] [CacheEvictionProbe] Setup: save path = /Users/mattkneale/Library/Containers/com.butterbar.app.EngineService/Data/tmp/
+2026-04-16 11:27:28.536 EngineService[91780:2327330] [CacheEvictionProbe] Setup: adding magnet magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&tr=udp%3A%2F%2Fexplodie.org%3A6969
+2026-04-16 11:27:28.537 EngineService[91780:2327330] [CacheEvictionProbe] Setup: torrent id = 6B5B41ED-955B-4E67-89D7-8E8497BF3B06
+2026-04-16 11:27:28.537 EngineService[91780:2327330] [CacheEvictionProbe] Setup: waiting up to 60s for torrent metadata...
+2026-04-16 11:27:28.784 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] 127.0.0.1:6881
+2026-04-16 11:27:28.784 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] 127.0.0.1:6881
+2026-04-16 11:27:28.784 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] 192.168.1.102:6881
+2026-04-16 11:27:28.784 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] 192.168.1.102:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [::1]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [::1]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::1%lo0]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::1%lo0]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::c24:3ee6:3424:caad%en0]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::c24:3ee6:3424:caad%en0]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fd71:ee32:179f:4737:1407:758b:d3ac:411]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fd71:ee32:179f:4737:1407:758b:d3ac:411]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::4c03:fdff:fe77:15a%awdl0]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::4c03:fdff:fe77:15a%awdl0]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::4c03:fdff:fe77:15a%llw0]:6881
+2026-04-16 11:27:28.785 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::4c03:fdff:fe77:15a%llw0]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::81d0:2bb:e893:6fe4%utun0]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::81d0:2bb:e893:6fe4%utun0]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::7960:5680:38cf:ea04%utun1]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::7960:5680:38cf:ea04%utun1]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::e9fd:52e8:ff93:5578%utun2]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::e9fd:52e8:ff93:5578%utun2]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::ce81:b1c:bd2c:69e%utun3]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::ce81:b1c:bd2c:69e%utun3]:6881
+2026-04-16 11:27:28.786 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::add3:e93c:dc36:1804%utun4]:6881
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::add3:e93c:dc36:1804%utun4]:6881
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::5dac:38be:3cf5:3669%utun5]:6881
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::5dac:38be:3cf5:3669%utun5]:6881
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [TCP] [fe80::ce52:5d51:ec7e:d232%utun6]:6881
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=listen_succeeded msg=successfully listening on [uTP] [fe80::ce52:5d51:ec7e:d232%utun6]:6881
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=lsd_error msg=Local Service Discovery startup error [::1]: Can't assign requested address
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=lsd_error msg=Local Service Discovery startup error [fd71:ee32:179f:4737:1407:758b:d3ac:411]: Can't assign requested address
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=torrent_added msg=Big Buck Bunny added
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=state_changed msg=Big Buck Bunny: state changed to: dl metadata
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=add_torrent msg=added torrent: Big Buck Bunny
+2026-04-16 11:27:28.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=external_ip msg=external IP received: 146.200.51.215
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=torrent_resumed msg=Big Buck Bunny resumed
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::ce52:5d51:ec7e:d232%utun6]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::5dac:38be:3cf5:3669%utun5]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::add3:e93c:dc36:1804%utun4]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::ce81:b1c:bd2c:69e%utun3]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::e9fd:52e8:ff93:5578%utun2]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::7960:5680:38cf:ea04%utun1]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.288 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::81d0:2bb:e893:6fe4%utun0]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.289 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::4c03:fdff:fe77:15a%llw0]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.289 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::4c03:fdff:fe77:15a%awdl0]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.289 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fd71:ee32:179f:4737:1407:758b:d3ac:411]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.289 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::c24:3ee6:3424:caad%en0]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.289 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::1%lo0]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.289 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[::1]:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.289 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[127.0.0.1:6881] v1 skipping tracker announce (unreachable) "" (1)
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=metadata_received msg=Big Buck Bunny metadata successfully received
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=state_changed msg=Big Buck Bunny: state changed to: checking (r)
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=state_changed msg=Big Buck Bunny: state changed to: checking
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 0 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 2 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 3 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 4 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 5 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 6 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 7 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 8 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 9 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 10 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 11 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 18 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 19 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 20 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 21 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 22 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 23 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 24 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 25 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 31 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 32 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 33 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 34 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 35 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 36 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 37 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 38 finished downloading
+2026-04-16 11:27:29.787 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 53 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 54 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 55 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 56 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 69 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 70 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 71 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 72 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 73 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 74 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 75 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 76 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 77 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 78 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 79 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 80 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 81 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 82 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 83 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 84 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 85 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 86 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 87 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 88 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 89 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 90 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 91 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 92 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 93 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 94 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 95 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 96 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 97 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 98 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 99 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 100 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 101 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 102 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 103 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 104 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 105 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 106 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 107 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 108 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 109 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 110 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 111 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 112 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 113 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 114 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 115 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 116 finished downloading
+2026-04-16 11:27:29.788 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 117 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 118 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 119 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 120 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 121 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 122 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 123 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 125 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 126 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 127 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 128 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 129 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 130 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 131 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 132 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 133 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 134 finished downloading
+2026-04-16 11:27:30.036 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 135 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 136 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 137 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 138 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 139 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 140 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 141 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 142 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 143 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 144 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 145 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 146 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 147 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 148 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 149 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 150 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 151 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 152 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 153 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 154 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 155 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 156 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 157 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 158 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 159 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 160 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 161 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 162 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 163 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 164 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 166 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 167 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 168 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 169 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 170 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 171 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 172 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 174 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 175 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 176 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 177 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 178 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 179 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 180 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 181 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 182 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 183 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 184 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 185 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 186 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 187 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 188 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 189 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 190 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 191 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 192 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 193 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 194 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 195 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 196 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 197 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 198 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 199 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 200 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 201 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 202 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 203 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 204 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 205 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 206 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 207 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 208 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 209 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 210 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 212 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 213 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 214 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 215 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 216 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 217 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 218 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 219 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 220 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 221 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 222 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 223 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 224 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 225 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 226 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 227 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 228 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 229 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 230 finished downloading
+2026-04-16 11:27:30.037 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 231 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 232 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 233 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 234 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 235 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 236 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 237 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 238 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 239 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 240 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 241 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 242 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 243 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 244 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 245 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 246 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 247 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 248 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 249 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 250 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 251 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 252 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 253 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 254 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 255 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 256 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 257 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 258 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 259 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 260 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 261 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 262 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 263 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 264 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 265 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 266 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 267 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 268 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 269 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 270 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 271 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 272 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 273 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 274 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 275 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 276 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 278 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 279 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 280 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 281 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 282 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 283 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 284 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 285 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 286 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 287 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 288 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 289 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 290 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 291 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 292 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 293 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 294 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 295 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 296 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 297 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 298 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 299 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 302 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 303 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 304 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 305 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 306 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 307 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 309 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 310 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 311 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 312 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 313 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 314 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 315 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 316 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 317 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 318 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 319 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 321 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 322 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 329 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 330 finished downloading
+2026-04-16 11:27:30.038 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 331 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 332 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 333 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 334 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 335 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 336 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 337 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 338 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 339 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 340 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 341 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 342 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 343 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 344 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 345 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 346 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 347 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 348 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 349 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 350 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 351 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 352 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 353 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 354 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 355 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 356 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 357 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 358 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 359 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 360 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 361 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 362 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 363 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 364 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 365 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 366 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 367 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 368 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 369 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 370 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 371 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 372 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 373 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 374 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 375 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 376 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 377 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 378 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 379 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 380 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 381 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 389 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 390 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 391 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 392 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 393 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 394 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 395 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 396 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 397 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 398 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 399 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 400 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 401 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 402 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 403 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 404 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 405 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 406 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 407 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 408 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 409 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 410 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 411 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 412 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 413 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 414 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 415 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 416 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 417 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 418 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 419 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 420 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 421 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 422 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 423 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 424 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 425 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 426 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 427 finished downloading
+2026-04-16 11:27:30.039 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 428 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 429 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 430 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 431 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 432 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 433 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 434 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 435 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 436 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 437 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 438 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 439 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 440 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 441 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 442 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 443 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 444 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 445 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 446 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 447 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 448 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 449 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 450 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 451 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 452 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 453 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 454 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 455 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 456 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 457 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 458 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 459 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 460 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 461 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 462 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 463 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 464 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 465 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 466 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 467 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 468 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 469 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 470 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 471 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 472 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 473 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 474 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 475 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 476 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 478 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 479 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 480 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 482 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 483 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 484 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 485 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 486 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 487 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 488 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 489 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 490 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 491 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 492 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 493 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 494 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 495 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 496 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 497 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 498 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 499 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 500 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 502 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 503 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 504 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 505 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 506 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 507 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 508 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 509 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 510 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 511 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 512 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 513 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 514 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 515 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 516 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 517 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 518 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 519 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 520 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 521 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 522 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 523 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 524 finished downloading
+2026-04-16 11:27:30.040 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 525 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 526 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 527 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 528 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 529 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 530 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 542 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 545 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 546 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 547 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 548 finished downloading
+2026-04-16 11:27:30.041 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 549 finished downloading
+2026-04-16 11:27:30.054 EngineService[91780:2327330] [CacheEvictionProbe] Setup: metadata arrived — piece length = 262144 bytes
+2026-04-16 11:27:30.055 EngineService[91780:2327330] [CacheEvictionProbe] Setup: file count = 3
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe]   file[0]: path=Big Buck Bunny/Big Buck Bunny.en.srt size=140 bytes
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe]   file[1]: path=Big Buck Bunny/Big Buck Bunny.mp4 size=276134947 bytes
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe]   file[2]: path=Big Buck Bunny/poster.jpg size=310380 bytes
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] Setup: totalBytes=276445467 pieceCount~=1055
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] Setup: auto-selected largest file at index 1 (size=276134947 bytes)
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] Setup: probing file: Big Buck Bunny/Big Buck Bunny.mp4
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] Setup: waiting up to 120s for at least 8 pieces of target file to download...
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe]   downloaded 505 piece(s) — proceeding
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] Setup: on-disk path resolved: /Users/mattkneale/Library/Containers/com.butterbar.app.EngineService/Data/tmp/Big Buck Bunny/Big Buck Bunny.mp4
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] 
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] --- Probe A: file state BEFORE priority change ---
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] Probe A: file size=276134947 bytes, on-disk=254377984 bytes
+2026-04-16 11:27:30.056 EngineService[91780:2327330] [CacheEvictionProbe] Probe A: sparse ratio = 92.1%
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe] Probe A: havePieces count=506, indices=[0, 1, 2, 3, 4, 5, 6, 7]...
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe] 
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe] --- Probe B: set file priority to 0 (ignore), observe file state ---
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe]   Note: TorrentBridge exposes setFilePriority (file granularity) only.
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe]   Per-piece priority (lt::torrent_handle::piece_priority) is NOT bridged.
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe]   This probe uses file-level priority as the coarsest available lever.
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe] Probe B: setFilePriority(6B5B41ED-955B-4E67-89D7-8E8497BF3B06, fileIndex:1, priority:0) succeeded
+2026-04-16 11:27:30.057 EngineService[91780:2327330] [CacheEvictionProbe] Probe B (immediate): file size=276134947, on-disk=254377984
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 550 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 551 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 552 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 553 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 554 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 555 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 556 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 557 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 558 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 559 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 560 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 561 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 562 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 563 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 564 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 565 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 566 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 567 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 568 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 569 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 570 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 575 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 576 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 577 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 578 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 579 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 580 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 581 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 582 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 583 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 584 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 585 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 586 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 587 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 588 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 589 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 590 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 591 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 592 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 593 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 594 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 595 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 596 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 597 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 598 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 599 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 600 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=file_prio msg=Big Buck Bunny file priorities updated
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 602 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 605 finished downloading
+2026-04-16 11:27:30.288 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 606 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 601 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 603 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 608 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 609 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 611 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 612 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 610 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 620 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 621 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 622 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 623 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 624 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 625 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 626 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 632 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 633 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 634 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 635 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 636 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 637 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 638 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 639 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 640 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 641 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 642 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 643 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 644 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 645 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 646 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 647 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 648 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 649 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 650 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 651 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 652 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 653 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 654 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 655 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 657 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 658 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 659 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 660 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 663 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 664 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 665 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 666 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 667 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 668 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 669 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 670 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 671 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 672 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 673 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 674 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 675 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 676 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 677 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 678 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 679 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 680 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 681 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 682 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 683 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 684 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 685 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 686 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 687 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 688 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 689 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 690 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 691 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 692 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 693 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 694 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 695 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 696 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 697 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 698 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 703 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 704 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 705 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 706 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 707 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 708 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 709 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 710 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 711 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 712 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 713 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 714 finished downloading
+2026-04-16 11:27:30.289 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 715 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 716 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 717 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 718 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 719 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 720 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 721 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 722 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 723 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 724 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 725 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 726 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 727 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 728 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 729 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 730 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 731 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 732 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 733 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 734 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 735 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 736 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 737 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 738 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 739 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 740 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 741 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 742 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 743 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 744 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 745 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 746 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 747 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 748 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 749 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 750 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 751 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 752 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 753 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 754 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 755 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 756 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 757 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 759 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 760 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 761 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 762 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 763 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 764 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 765 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 766 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 767 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 769 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 770 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 771 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 772 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 774 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 775 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 776 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 777 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 778 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 779 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 780 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 781 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 782 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 783 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 784 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 785 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 786 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 787 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 788 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 789 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 790 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 791 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 792 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 793 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 794 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 795 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 796 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 797 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 798 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 799 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 800 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 801 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 802 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 803 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 804 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 805 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 806 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 807 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 808 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 809 finished downloading
+2026-04-16 11:27:30.290 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 810 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 811 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 812 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 813 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 814 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 815 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 816 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 817 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 818 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 819 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 820 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 821 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 822 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 823 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 824 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 825 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 826 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 827 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 828 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 829 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 830 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 831 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 832 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 833 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 834 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 835 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 836 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 837 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 838 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 839 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 840 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 841 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 842 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 843 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 844 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 845 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 846 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 847 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 848 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 849 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 850 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 851 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 852 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 853 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 854 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 855 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 856 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 857 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 858 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 859 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 860 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 861 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 862 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 863 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 864 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 865 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 866 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 867 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 868 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 869 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 870 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 871 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 872 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 873 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 874 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 875 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 876 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 877 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 878 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 879 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 880 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 881 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 882 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 883 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 884 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 885 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 886 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 887 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 888 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 889 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 890 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 891 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 892 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 893 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 894 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 895 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 896 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 897 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 898 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 899 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 900 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 901 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 902 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 903 finished downloading
+2026-04-16 11:27:30.291 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 904 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 905 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 906 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 907 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 908 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 909 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 910 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 921 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 922 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 923 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 924 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 925 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 926 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 927 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 928 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 929 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 930 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 931 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 932 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 933 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 934 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 935 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 936 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 937 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 938 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 939 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 940 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 941 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 942 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 943 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 944 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 945 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 946 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 947 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 948 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 949 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 950 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 951 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 952 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 953 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 954 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 955 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 956 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 957 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 958 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 959 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 960 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 961 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 962 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 963 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 964 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 965 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 966 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 967 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 968 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 969 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 970 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 971 finished downloading
+2026-04-16 11:27:30.292 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 972 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 973 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 974 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 975 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 976 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 977 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 978 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 979 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 980 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 981 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 982 finished downloading
+2026-04-16 11:27:30.538 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 983 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 984 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 985 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 986 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 987 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 988 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 989 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 990 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 991 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 992 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 993 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 994 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 995 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 996 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 997 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 998 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 999 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1000 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1001 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1003 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1004 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1005 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1006 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1008 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1009 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1010 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1011 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1012 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1013 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1014 finished downloading
+2026-04-16 11:27:30.539 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1015 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1016 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1017 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1018 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1019 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1020 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1021 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1022 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1023 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1024 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1025 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1026 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1027 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1029 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1030 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1031 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1032 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1033 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1034 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1035 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1036 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1037 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1038 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1039 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1041 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1042 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1043 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1044 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1045 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1046 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1047 finished downloading
+2026-04-16 11:27:30.540 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1048 finished downloading
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1049 finished downloading
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1050 finished downloading
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1051 finished downloading
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1053 finished downloading
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=piece_finished msg=Big Buck Bunny piece: 1054 finished downloading
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=state_changed msg=Big Buck Bunny: state changed to: finished
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=torrent_finished msg=Big Buck Bunny torrent finished downloading
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=torrent_checked msg=Big Buck Bunny checked
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[127.0.0.1:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[::1]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::1%lo0]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::c24:3ee6:3424:caad%en0]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fd71:ee32:179f:4737:1407:758b:d3ac:411]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::4c03:fdff:fe77:15a%awdl0]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::4c03:fdff:fe77:15a%llw0]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::81d0:2bb:e893:6fe4%utun0]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.541 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::7960:5680:38cf:ea04%utun1]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.542 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::e9fd:52e8:ff93:5578%utun2]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.542 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::ce81:b1c:bd2c:69e%utun3]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.542 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::add3:e93c:dc36:1804%utun4]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.542 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::5dac:38be:3cf5:3669%utun5]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.542 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=tracker_error msg=Big Buck Bunny (udp://explodie.org:6969)[[fe80::ce52:5d51:ec7e:d232%utun6]:6881] v1 skipping tracker announce (unreachable) "" (2)
+2026-04-16 11:27:30.542 EngineService[91780:2327344] [CacheEvictionProbe:alert] type=cache_flushed msg=Big Buck Bunny
+2026-04-16 11:27:32.062 EngineService[91780:2327330] [CacheEvictionProbe] Probe B (after 2s): file size=276134947, on-disk=254377984
+2026-04-16 11:27:32.062 EngineService[91780:2327330] [CacheEvictionProbe] Probe B: havePieces count=937 (did priority=0 evict pieces?)
+2026-04-16 11:27:32.062 EngineService[91780:2327330] [CacheEvictionProbe] 
+2026-04-16 11:27:32.062 EngineService[91780:2327330] [CacheEvictionProbe] --- Probe C: attempt F_PUNCHHOLE on file region ---
+2026-04-16 11:27:32.062 EngineService[91780:2327330] [CacheEvictionProbe]   Hypothesis: libtorrent does not truncate/sparsify on priority=0;
+2026-04-16 11:27:32.062 EngineService[91780:2327330] [CacheEvictionProbe]   the app must call F_PUNCHHOLE itself to reclaim APFS disk space.
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe] Probe C: file size before punch = 276134947 bytes
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe] Probe C: F_PUNCHHOLE failed: Invalid argument (errno=22)
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe]   On HFS+: ENOTSUP is expected (no sparse file support).
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe]   On APFS: success is expected.
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe] Probe C: after F_PUNCHHOLE — file size=276134947, on-disk=254377984
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe] Probe C: RESULT: disk blocks unchanged — punch had no effect.
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe] Probe C: havePieces count=937 after punch (libtorrent's view unchanged?)
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe] Probe C: readBytes from punched region returned 4096 bytes
+2026-04-16 11:27:32.063 EngineService[91780:2327330] [CacheEvictionProbe]   (non-nil means libtorrent served bytes; are they zeros from the hole?)
+2026-04-16 11:27:32.064 EngineService[91780:2327330] [CacheEvictionProbe]   data is all-zero: false
+2026-04-16 11:27:32.064 EngineService[91780:2327330] [CacheEvictionProbe] 
+2026-04-16 11:27:32.064 EngineService[91780:2327330] [CacheEvictionProbe] Probe C (truncate variant): attempt ftruncate to see libtorrent's reaction
+2026-04-16 11:27:32.137 EngineService[91780:2327330] [CacheEvictionProbe] Probe C (truncate): ftruncate to 138067473 succeeded
+2026-04-16 11:27:32.137 EngineService[91780:2327330] [CacheEvictionProbe] Probe C (truncate): file size=138067473, on-disk=124993536
+2026-04-16 11:27:34.143 EngineService[91780:2327330] [CacheEvictionProbe] Probe C (truncate): havePieces after 2s = 937 pieces
+2026-04-16 11:27:34.143 EngineService[91780:2327330] [CacheEvictionProbe] 
+2026-04-16 11:27:34.143 EngineService[91780:2327330] [CacheEvictionProbe] --- Probe D: restore file priority to 1, wait for re-fetch ---
+2026-04-16 11:27:34.143 EngineService[91780:2327330] [CacheEvictionProbe] Probe D: setFilePriority(6B5B41ED-955B-4E67-89D7-8E8497BF3B06, fileIndex:1, priority:1) succeeded
+2026-04-16 11:27:34.143 EngineService[91780:2327330] [CacheEvictionProbe] Probe D: waiting up to 15s for re-fetch...
+2026-04-16 11:27:34.284 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=state_changed msg=Big Buck Bunny: state changed to: downloading
+2026-04-16 11:27:34.284 EngineService[91780:2327343] [CacheEvictionProbe:alert] type=file_prio msg=Big Buck Bunny file priorities updated
+2026-04-16 11:27:34.649 EngineService[91780:2327330] [CacheEvictionProbe]   attempt 1: havePieces count=937
+2026-04-16 11:27:34.649 EngineService[91780:2327330] [CacheEvictionProbe]   piece count restored — stopping early
+2026-04-16 11:27:34.649 EngineService[91780:2327330] [CacheEvictionProbe] Probe D: final havePieces count=937
+2026-04-16 11:27:34.650 EngineService[91780:2327330] [CacheEvictionProbe]   indices=[0, 1, 2, 3, 4, 5, 6, 7]...
+2026-04-16 11:27:34.650 EngineService[91780:2327330] [CacheEvictionProbe] Probe D: file size=276134947, on-disk=125046784
+2026-04-16 11:27:37.284 EngineService[91780:2327330] [CacheEvictionProbe] 
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe] === T-CACHE-EVICTION probe complete ===
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe] Downloaded content left at: /Users/mattkneale/Library/Containers/com.butterbar.app.EngineService/Data/tmp/  (intentional — re-runs skip re-download)
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe] Copy all lines above into docs/libtorrent-eviction-notes.md
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe] 
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe] Key questions to answer from the output:
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe]   1. Did setFilePriority(0) change on-disk bytes? (Probe A vs B)
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe]   2. Did F_PUNCHHOLE succeed on this filesystem? (Probe C)
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe]   3. After punch, did libtorrent's havePieces still show the punched pieces? (Probe C)
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe]   4. After ftruncate, did libtorrent automatically re-expand the file? (Probe C truncate)
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe]   5. After restoring priority=1, did libtorrent re-fetch the missing pieces? (Probe D)
+2026-04-16 11:27:37.285 EngineService[91780:2327330] [CacheEvictionProbe]   6. What is the piece length for this torrent? (Setup output)
 
-## Probe run (2026-04-16)
+## 2026-04-16 follow-up: libtorrent 2.0.12 API surface constraint
 
-First attempt to run `EngineService --cache-eviction-probe` revealed a blocker upstream of eviction itself.
+After the initial probe run, the next intended step was to add a `clearPieces(torrentID:, pieces:)` method to `TorrentBridge` wrapping `lt::torrent_handle::clear_piece(piece_index_t)` so we could surgically invalidate libtorrent's have-bitmap after punching holes. **That method does not exist on `torrent_handle` in libtorrent 2.0.12.**
 
-### pbxproj fixes applied before run
+### What's actually in the 2.0.12 public API
 
-1. **UUID collision** — the T-UI-LIBRARY follow-up added a `PBXContainerItemProxy` with UUID `AA11BB22CC33DD44EE55FF66`, which collided with an existing `PBXBuildFile` entry for `EngineClient.swift`. Xcode refused to open the project with "unrecognized selector sent to instance" on PBXContainerItemProxy. Fixed by reassigning the proxy to `D1000001000000000000DD01`.
+Checked against `/opt/homebrew/Cellar/libtorrent-rasterbar/2.0.12/include/libtorrent/torrent_handle.hpp`:
 
-2. **Missing target registration** — `CacheEvictionProbe.swift` existed on disk but was never added to the EngineService Xcode target (no PBXFileReference, no PBXBuildFile, no group membership, no Sources build phase entry). Added under UUIDs `E1000001000000000000EE01` (build file) and `E1000002000000000000EE02` (file reference).
+- `clear_piece` is declared only on the internal `disk_interface` (`disk_interface.hpp:327: async_clear_piece`). It's invoked by libtorrent when a piece fails its hash check. Not reachable from `torrent_handle`.
+- The public reconciliation methods we have are:
+  - `force_recheck()` — re-verifies the entire torrent against disk. O(on-disk bytes). Heavy; pauses peers during the check.
+  - `piece_priority(idx, 0)` — gates future downloads only; no effect on existing have-bitmap.
+  - `add_piece(idx, data, overwrite_existing)` — writes `data` to disk, then hash-checks. Hash failure internally calls `async_clear_piece` and removes the piece from the have-bitmap.
 
-3. **Swift compile error** — `data.withUnsafeMutableBytes { ptr in ... ptr[i] = ... }` was ambiguous. Fixed with explicit `(ptr: UnsafeMutableRawBufferPointer)` annotation.
+### Chosen v1 mechanism
 
-### Probe failure: createTestTorrent returns "Operation canceled"
+**Primary eviction hot path — per-piece, surgical:**
 
-After fixing the above, the probe runs but fails immediately on the `createTestTorrent` step:
+1. `add_piece(idx, 256 KB of zeros, overwrite_existing)` — libtorrent writes the buffer to disk, then hash-checks. Zeros will not match the piece hash.
+2. Wait for `hash_failed_alert` on that piece index. On receipt, libtorrent has internally run `async_clear_piece` and removed the piece from the have-bitmap.
+3. `fcntl(fd, F_PUNCHHOLE, ...)` over the piece-aligned byte range to reclaim the APFS blocks that were just re-allocated by the zero write.
+4. Restoring `piece_priority(idx, 1)` (or file priority ≥ 1) then triggers re-fetch on next access.
 
-```
-[CacheEvictionProbe] === T-CACHE-EVICTION probe starting ===
-[CacheEvictionProbe] Setup: wrote 262144 byte source file at /Users/.../source/probe.bin
-[CacheEvictionProbe] ERROR: createTestTorrent failed: Error Domain=com.butterbar.engine Code=4 "Operation canceled"
-```
+The punch comes *after* the hash failure is confirmed, not before. `add_piece` writes its buffer to disk before hashing, which would re-allocate any pre-existing hole.
 
-### Root cause: T-STREAM-E2E was never runtime-verified
+**Fallback — bulk reconciliation:**
 
-Running the same helper via `--stream-e2e-self-test`:
+`force_recheck()` — called only (a) during engine idle periods for bulk reconciliation and (b) as recovery if `add_piece`-driven hash failure stops working in a future libtorrent version. Not used on the eviction hot path.
 
-```
-[StreamE2ESelfTest] Starting end-to-end stream self-test…
-[StreamE2ESelfTest] FAILED — 1 failure(s):
-[StreamE2ESelfTest]   FAIL: createTestTorrent threw: Error Domain=com.butterbar.engine Code=4 "Operation canceled" (line 66)
-```
+### Risk
 
-Both the probe and T-STREAM-E2E fail with the exact same error. This means the `createTestTorrent` helper added in T-BRIDGE-API has never actually executed successfully — Phase 5's Opus review of T-STREAM-E2E was a code review only, not a runtime verification. The task acceptance criteria ("recorded video of successful playback committed") was always going to surface this.
+The primary mechanism trades on an implementation detail: libtorrent currently writes every `add_piece` buffer to disk and then hashes it. If a future libtorrent optimises this path (e.g., short-circuits writes when the hash would obviously fail), the add_piece hash-fail trick could stop invoking `async_clear_piece`. The fallback is `force_recheck`; the planner can fall through to it.
 
-### Where the error comes from
+### Next probe (to validate the mechanism before CacheManager lands)
 
-Error code 4 = `TorrentBridgeErrorReadError`, returned from `createTestTorrent` in `TorrentBridge.mm` when `lt::set_piece_hashes(ct, sourceDir, ec)` writes into `ec`. The message "Operation canceled" is libtorrent/boost asio's generic cancellation error, returned nearly instantly (microseconds between the file-write log and the error), which suggests libtorrent bails before doing any real hashing work.
+A revised probe will exercise both mechanisms head-to-head on a real torrent:
 
-### Hypotheses to investigate
+- Probe C1: `add_piece(zeros, overwrite_existing)` on a downloaded piece → expect `hash_failed_alert` → expect that piece to leave `havePieces()` → punch the hole → expect on-disk bytes to decrease by ~one piece length.
+- Probe C2: Repeat with a different piece but use `force_recheck()` → expect every downloaded piece to re-appear in `havePieces()` after the check completes (the baseline should be unchanged because the file is still intact).
+- Probe C3: After C1, set file priority back to 1 → expect the hash-failed piece to be re-downloaded and re-appear in `havePieces()`.
 
-1. **Sandbox / entitlements.** EngineService is an XPC service with App Sandbox enabled. Container path is `~/Library/Containers/com.butterbar.app.EngineService/Data/tmp/...`. libtorrent's `add_files` might enumerate the directory successfully (returning `num_files() > 0`), but `set_piece_hashes` might then hit a permission denial when opening the file for hashing — and on macOS APFS through boost asio, this can surface as "Operation canceled" rather than EPERM.
-
-2. **libtorrent 2.0.12 API change.** The 2.x series may require a disk_io_thread or explicit session/ioc to be set up before `set_piece_hashes` can run. The synchronous overload may have been removed or require extra setup.
-
-3. **Entitlement missing.** The EngineService may need `com.apple.security.temporary-exception.files.absolute-path.read-only` or similar to read its own sandbox container paths under `~/Library/Containers/`.
-
-### Resolution: probe rewritten to bypass createTestTorrent
-
-The probe no longer uses `createTestTorrent`. Instead it accepts a real magnet link or
-`.torrent` file path on the command line, bypassing the sandboxed hash-creation step
-entirely. `addMagnet` is already known to work in the XPC sandbox (used by XPC tests).
-
-## Running the probe (new interface)
-
-Build EngineService in Debug configuration first:
-
-```
-xcodebuild -scheme EngineService -configuration Debug build
-```
-
-Then run with a magnet link. The Internet Archive Big Buck Bunny torrent (~160 MB MP4)
-is well-seeded and small enough to make a practical probe target:
-
-```
-/path/to/EngineService.xpc/Contents/MacOS/EngineService \
-  --cache-eviction-probe \
-  "magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&tr=udp%3A%2F%2Fexplodie.org%3A6969"
-```
-
-To probe a specific file (e.g. file index 2 in a multi-file torrent):
-
-```
-EngineService --cache-eviction-probe "magnet:..." --file-index 2
-```
-
-To probe a local `.torrent` file:
-
-```
-EngineService --cache-eviction-probe /path/to/file.torrent
-```
-
-Running without arguments prints usage and exits 1.
-
-### What the probe logs
-
-1. **Setup** — torrent ID, save path, piece length
-2. **File list** — all files with index, path, size
-3. **Selected file** — which file was probed (largest by default)
-4. **Metadata wait** — times out at 60s with exit 2 if no metadata arrives
-5. **Download wait** — waits up to 120s for ≥8 pieces; reports progress every 10s
-6. **Probe A** — baseline stat before priority change
-7. **Probe B** — stat immediately and 2s after `setFilePriority(0)`
-8. **Probe C** — F_PUNCHHOLE + ftruncate attempts, libtorrent's view after each
-9. **Probe D** — stat after restoring `setFilePriority(1)`, re-fetch wait
-
-### Where downloaded content lives
-
-Downloaded files are saved to `NSTemporaryDirectory()` — the same save path
-`addMagnet` always uses (hardcoded in `TorrentBridge.mm`). On macOS inside the
-EngineService sandbox this is typically:
-
-```
-~/Library/Containers/com.butterbar.app.EngineService/Data/tmp/
-```
-
-The probe intentionally leaves content there after finishing so re-runs are fast.
-
-### Timeout exit codes
-
-- `exit(1)` — bad arguments / usage error
-- `exit(2)` — `METADATA_TIMEOUT` (60s) or `DOWNLOAD_TIMEOUT` (120s)
-- `exit(0)` — probes ran to completion
-
-### Pending observations
-
-Paste NSLog output here after running:
-
-- Probe A: baseline file size + on-disk bytes before eviction
-- Probe B: behavior when `setFilePriority(priority:0)` is called
-- Probe C: fcntl F_PUNCHHOLE + ftruncate attempts against the real file
-- Probe D: re-fetch behavior when priority restored to 1
-
-### Implications for Phase 5
-
-The `createTestTorrent` blocker is now bypassed at the probe level. T-STREAM-E2E
-still needs a fix for `createTestTorrent` if it is to run end-to-end — that is a
-separate task. The cache-eviction probe can now run independently using a real magnet.
-
+The revised probe requires two new `TorrentBridge` methods: `forceRecheck(torrentID:)` and `addPiece(torrentID:, piece:, data:, overwriteExisting:)`. Both map 1:1 onto the lt API.


### PR DESCRIPTION
Closes #100.

## Summary

libtorrent 2.0.12 does not expose `torrent_handle::clear_piece` in its public API — it exists only on the internal `disk_interface`. The spec's hand-wavy "truncate where possible / mark for future overwrite" wording is replaced with a concrete two-tier mechanism built from the public API, recorded in addendum **A23** and spec **05 rev 3**:

- **Hot path (per piece, surgical):** `addPiece(zeros, overwrite_existing)` → `hash_failed_alert` → `F_PUNCHHOLE` on the piece-aligned byte range → priority restore for re-fetch. The intentional hash failure invokes libtorrent's internal `async_clear_piece` and removes the piece from the have-bitmap.
- **Fallback (bulk, idle):** `forceRecheck()` — for idle-time reconciliation and recovery if the add_piece trick ever stops working.

No CacheManager implementation in this PR — that waits on the revised probe's output on real hardware.

## What's in the PR

**Docs (`50db49f`):**
- `.claude/specs/00-addendum.md` — new item A23
- `.claude/specs/05-cache-policy.md` — rev 3, § Piece eviction mechanism rewritten
- `.claude/tasks/TASKS.md` — T-CACHE-EVICTION → IN-PROGRESS
- `docs/libtorrent-eviction-notes.md` — API-surface finding + next-probe plan

**Bridge + probe (`42ca5ff`):**
- `TorrentBridge.addPiece(torrentID:piece:data:overwriteExisting:)` — wraps `lt::torrent_handle::add_piece`
- `TorrentBridge.forceRecheck(torrentID:)` — wraps `lt::torrent_handle::force_recheck`
- `_drainAlerts` now attaches `pieceIndex` to `hash_failed_alert` and `piece_finished_alert`
- `CacheEvictionProbe.swift` — old Probe C (punch-at-0 + ftruncate) replaced with C1 (addPiece+punch), C2 (force_recheck), C3 (priority restore → re-fetch)

**Review fixups (`536eefd`):**
- `addPiece` validates `data.length == ti->piece_size(piece)` (new error code `TorrentBridgeErrorInvalidArgument = 6`)
- `forceRecheck` doc expanded with all four side effects (resume reset, peer disconnect, tracker pause, queue position)
- `addPiece` doc expanded with `piece_size` / `pieceLength` distinction, checking_files caveat, and overwrite_existing caveat for in-flight pieces
- `subscribeAlerts` doc documents the `pieceIndex` dict key
- Probe key-questions list adds Q3 on the priority=0 × addPiece interaction
- Probe has a comment explaining why mid-probe `subscribeAlerts` replacement is race-free

## Verification

- [x] `xcodebuild -project ButterBar.xcodeproj -scheme EngineService -configuration Debug build` — `** BUILD SUCCEEDED **`
- [x] Opus review: APPROVE WITH FOLLOW-UPS; all API-surface follow-ups addressed in `536eefd`
- [ ] User runs `EngineService --cache-eviction-probe <magnet>` on real hardware; paste output into `docs/libtorrent-eviction-notes.md`. The probe's Q1–Q9 should be answerable from the output.

## What this PR does NOT do

- CacheManager eviction implementation (blocked until probe-run evidence confirms the mechanism on real libtorrent).
- Probe run (requires network + real peers — user action).
- Alert-category grace tuning (Probe C1 uses a 2s post-hash-fail retry; `alert_types.hpp:929-931` flags this as potentially flush-dependent; tune against real observations if flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)