### PR TITLE
Engine: T-PERF-SEEK-BENCH — planner replay bench + baseline

### DIFF
--- a/Packages/PlannerCore/Tests/PlannerCoreTests/PlannerSeekBenchRecorder.swift
+++ b/Packages/PlannerCore/Tests/PlannerCoreTests/PlannerSeekBenchRecorder.swift
@@ -1,0 +1,268 @@
+// PlannerSeekBenchRecorder.swift — Opt-in recorder that writes docs/benchmarks/seek-baseline.json.
+//
+// Skipped in normal test runs. Enable with:
+//   BUTTERBAR_RECORD_SEEK_BASELINE=1 swift test \
+//     --package-path Packages/PlannerCore \
+//     --filter PlannerSeekBenchRecorder
+//
+// Or via the convenience wrapper:
+//   ./scripts/run-seek-bench.sh --record
+
+import XCTest
+import Foundation
+@testable import PlannerCore
+import TestFixtures
+
+final class PlannerSeekBenchRecorder: XCTestCase {
+
+    private static let fixtureNames = [
+        "front-moov-mp4-001",
+        "back-moov-mp4-001",
+        "mkv-cues-001",
+        "immediate-seek-001",
+    ]
+
+    private static let sampleCount = 20
+
+    func test_recordSeekBaseline() throws {
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["BUTTERBAR_RECORD_SEEK_BASELINE"] != "1",
+            "Set BUTTERBAR_RECORD_SEEK_BASELINE=1 to record the seek baseline."
+        )
+
+        var fixtureResults: [String: FixtureResult] = [:]
+
+        for name in Self.fixtureNames {
+            let trace = try FixtureLoader.loadTrace(named: name)
+            var samples: [Double] = []
+
+            for _ in 0..<Self.sampleCount {
+                let start = DispatchTime.now()
+                replayTrace(trace)
+                let end = DispatchTime.now()
+                let elapsed = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000.0
+                samples.append(elapsed)
+            }
+
+            samples.sort()
+            let p50 = percentile(samples, pct: 0.50)
+            let p90 = percentile(samples, pct: 0.90)
+            let maxMs = samples.last ?? 0
+
+            // Count events and total actions for the baseline metadata.
+            let eventCount = trace.events.count
+            let actionCount = countActions(trace)
+
+            fixtureResults[name] = FixtureResult(
+                events: eventCount,
+                actions: actionCount,
+                replayMsP50: round3(p50),
+                replayMsP90: round3(p90),
+                replayMsMax: round3(maxMs),
+                samples: Self.sampleCount
+            )
+
+            // Print per-fixture summary for CI visibility.
+            print("[\(name)] events=\(eventCount) actions=\(actionCount) p50=\(round3(p50))ms p90=\(round3(p90))ms max=\(round3(maxMs))ms")
+        }
+
+        let baseline = Baseline(
+            measuredAt: isoTimestamp(),
+            plannerCommit: gitHead(),
+            host: HostInfo(arch: uname_m(), osVersion: swVers()),
+            fixtures: fixtureResults,
+            regressionThresholdPct: nil,
+            notes: "Threshold to be set by opus once SLA is defined. Bench currently advisory."
+        )
+
+        let outputURL = try outputFileURL()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(baseline)
+        try data.write(to: outputURL, options: .atomic)
+
+        print("Baseline written to \(outputURL.path)")
+    }
+
+    // MARK: - Replay
+
+    private func replayTrace(_ trace: Trace) {
+        let session = makeSession(from: trace)
+        let planner = DefaultPiecePlanner()
+        for event in trace.events {
+            session.step(to: event.tMs)
+            let plannerEvent = playerEvent(from: event)
+            _ = planner.handle(event: plannerEvent, at: Instant(event.tMs), session: session)
+        }
+    }
+
+    private func countActions(_ trace: Trace) -> Int {
+        let session = makeSession(from: trace)
+        let planner = DefaultPiecePlanner()
+        var total = 0
+        for event in trace.events {
+            session.step(to: event.tMs)
+            let plannerEvent = playerEvent(from: event)
+            let actions = planner.handle(event: plannerEvent, at: Instant(event.tMs), session: session)
+            total += actions.count
+        }
+        return total
+    }
+
+    private func makeSession(from trace: Trace) -> FakeTorrentSession {
+        FakeTorrentSession(
+            pieceLength: trace.pieceLength,
+            fileByteRange: ByteRange(start: trace.fileByteRange.start, end: trace.fileByteRange.end),
+            availabilitySchedule: trace.availabilitySchedule.map {
+                AvailabilityEntry(tMs: $0.tMs, havePieces: $0.havePieces)
+            },
+            downloadRateSchedule: trace.downloadRateSchedule.map {
+                ScalarEntry(tMs: $0.tMs, value: $0.bytesPerSec)
+            },
+            peerCountSchedule: trace.peerCountSchedule.map {
+                ScalarEntry(tMs: $0.tMs, value: Int64($0.count))
+            }
+        )
+    }
+
+    private func playerEvent(from traceEvent: TraceEvent) -> PlayerEvent {
+        switch traceEvent.kind {
+        case .head:
+            return .head
+        case .get(let requestID, let rangeStart, let rangeEnd):
+            return .get(requestID: requestID, range: ByteRange(start: rangeStart, end: rangeEnd))
+        case .cancel(let requestID):
+            return .cancel(requestID: requestID)
+        }
+    }
+
+    // MARK: - Math helpers
+
+    private func percentile(_ sorted: [Double], pct: Double) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        let idx = max(0, min(sorted.count - 1, Int((pct * Double(sorted.count)).rounded()) - 1))
+        return sorted[idx]
+    }
+
+    private func round3(_ v: Double) -> Double {
+        (v * 1000).rounded() / 1000
+    }
+
+    // MARK: - System info helpers
+
+    private func isoTimestamp() -> String {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime]
+        return fmt.string(from: Date())
+    }
+
+    private func gitHead() -> String {
+        shell("git", "rev-parse", "HEAD") ?? "unknown"
+    }
+
+    private func uname_m() -> String {
+        shell("uname", "-m") ?? "unknown"
+    }
+
+    private func swVers() -> String {
+        shell("sw_vers", "-productVersion") ?? "unknown"
+    }
+
+    private func shell(_ cmd: String, _ args: String...) -> String? {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = [cmd] + args
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = Pipe()
+        guard (try? proc.run()) != nil else { return nil }
+        proc.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Output path
+
+    /// Resolves docs/benchmarks/seek-baseline.json relative to the package root.
+    /// The package root is the directory containing Package.swift for PlannerCore.
+    private func outputFileURL() throws -> URL {
+        // Walk up from the test bundle to find the repo root (contains scripts/).
+        let repoRoot = try findRepoRoot()
+        let dir = repoRoot.appendingPathComponent("docs/benchmarks", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("seek-baseline.json")
+    }
+
+    private func findRepoRoot() throws -> URL {
+        // Start from the current working directory or the test bundle path.
+        var url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        for _ in 0..<10 {
+            let marker = url.appendingPathComponent("scripts/pr-lifecycle-hook.sh")
+            if FileManager.default.fileExists(atPath: marker.path) {
+                return url
+            }
+            url = url.deletingLastPathComponent()
+        }
+        // Fallback: use current directory.
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    }
+}
+
+// MARK: - Codable output types
+
+private struct Baseline: Encodable {
+    let measuredAt: String
+    let plannerCommit: String
+    let host: HostInfo
+    let fixtures: [String: FixtureResult]
+    let regressionThresholdPct: Double?
+    let notes: String
+
+    enum CodingKeys: String, CodingKey {
+        case measuredAt = "measured_at"
+        case plannerCommit = "planner_commit"
+        case host
+        case fixtures
+        case regressionThresholdPct = "regression_threshold_pct"
+        case notes
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(measuredAt, forKey: .measuredAt)
+        try container.encode(plannerCommit, forKey: .plannerCommit)
+        try container.encode(host, forKey: .host)
+        try container.encode(fixtures, forKey: .fixtures)
+        // Encode nil explicitly so the field appears as `null` in JSON.
+        try container.encode(regressionThresholdPct, forKey: .regressionThresholdPct)
+        try container.encode(notes, forKey: .notes)
+    }
+}
+
+private struct HostInfo: Encodable {
+    let arch: String
+    let osVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case arch
+        case osVersion = "os_version"
+    }
+}
+
+private struct FixtureResult: Encodable {
+    let events: Int
+    let actions: Int
+    let replayMsP50: Double
+    let replayMsP90: Double
+    let replayMsMax: Double
+    let samples: Int
+
+    enum CodingKeys: String, CodingKey {
+        case events
+        case actions
+        case replayMsP50 = "replay_ms_p50"
+        case replayMsP90 = "replay_ms_p90"
+        case replayMsMax = "replay_ms_max"
+        case samples
+    }
+}

--- a/Packages/PlannerCore/Tests/PlannerCoreTests/PlannerSeekBenchTests.swift
+++ b/Packages/PlannerCore/Tests/PlannerCoreTests/PlannerSeekBenchTests.swift
@@ -1,0 +1,86 @@
+// PlannerSeekBenchTests.swift — XCTest performance bench for DefaultPiecePlanner replay.
+//
+// Measures wall-clock time for replaying each of the 4 trace fixtures through the planner.
+// Catches planner-side regressions (accidental O(N²), allocation storms) without any real
+// network dependency.
+//
+// XCTest stores a baseline with stddev once accepted in Xcode UI. For headless CI the raw
+// numbers are captured by PlannerSeekBenchRecorder.
+//
+// To run: swift test --package-path Packages/PlannerCore --filter PlannerSeekBench
+
+import XCTest
+@testable import PlannerCore
+import TestFixtures
+
+final class PlannerSeekBenchTests: XCTestCase {
+
+    func test_seekBench_frontMoovMp4() throws {
+        let trace = try FixtureLoader.loadTrace(named: "front-moov-mp4-001")
+        measure(metrics: [XCTClockMetric()]) {
+            replayTrace(trace)
+        }
+    }
+
+    func test_seekBench_backMoovMp4() throws {
+        let trace = try FixtureLoader.loadTrace(named: "back-moov-mp4-001")
+        measure(metrics: [XCTClockMetric()]) {
+            replayTrace(trace)
+        }
+    }
+
+    func test_seekBench_mkvCues() throws {
+        let trace = try FixtureLoader.loadTrace(named: "mkv-cues-001")
+        measure(metrics: [XCTClockMetric()]) {
+            replayTrace(trace)
+        }
+    }
+
+    func test_seekBench_immediateSeek() throws {
+        let trace = try FixtureLoader.loadTrace(named: "immediate-seek-001")
+        measure(metrics: [XCTClockMetric()]) {
+            replayTrace(trace)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Replays all events through a fresh planner + fresh session each time.
+    /// Both are created inside the measure block so each iteration is independent.
+    private func replayTrace(_ trace: Trace) {
+        let session = makeSession(from: trace)
+        let planner = DefaultPiecePlanner()
+        for event in trace.events {
+            session.step(to: event.tMs)
+            let plannerEvent = playerEvent(from: event)
+            _ = planner.handle(event: plannerEvent, at: Instant(event.tMs), session: session)
+        }
+    }
+
+    private func makeSession(from trace: Trace) -> FakeTorrentSession {
+        FakeTorrentSession(
+            pieceLength: trace.pieceLength,
+            fileByteRange: ByteRange(start: trace.fileByteRange.start, end: trace.fileByteRange.end),
+            availabilitySchedule: trace.availabilitySchedule.map {
+                AvailabilityEntry(tMs: $0.tMs, havePieces: $0.havePieces)
+            },
+            downloadRateSchedule: trace.downloadRateSchedule.map {
+                ScalarEntry(tMs: $0.tMs, value: $0.bytesPerSec)
+            },
+            peerCountSchedule: trace.peerCountSchedule.map {
+                ScalarEntry(tMs: $0.tMs, value: Int64($0.count))
+            }
+        )
+    }
+
+    private func playerEvent(from traceEvent: TraceEvent) -> PlayerEvent {
+        switch traceEvent.kind {
+        case .head:
+            return .head
+        case .get(let requestID, let rangeStart, let rangeEnd):
+            return .get(requestID: requestID, range: ByteRange(start: rangeStart, end: rangeEnd))
+        case .cancel(let requestID):
+            return .cancel(requestID: requestID)
+        }
+    }
+}

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,60 @@
+# Planner Seek Bench
+
+## What this measures
+
+Replay wall-clock time for `DefaultPiecePlanner.handle(event:)` across each of the four
+trace fixtures. This is a **planner-only** bench — no real network, no libtorrent, no
+AVFoundation. It catches planner-side regressions such as accidental O(N²) algorithms or
+allocation storms.
+
+The planner path is synchronous and deterministic: given an event stream it produces an
+action list in a single pass. Typical replay time for the current fixture set is in the
+sub-millisecond range on Apple silicon.
+
+True user-visible seek latency (from `PlayerEvent.get` to first decoded frame) also
+includes libtorrent piece fetch and AVFoundation decode time. That end-to-end measurement
+is not captured here; it is deferred to a follow-up task once a numerical SLA is defined.
+
+## How to run
+
+**XCTest measure bench** (5 iterations, XCTest stores baseline on acceptance in Xcode UI):
+
+```bash
+./scripts/run-seek-bench.sh
+# or directly:
+swift test --package-path Packages/PlannerCore --filter PlannerSeekBench
+```
+
+**Baseline recorder** (20 iterations, writes `docs/benchmarks/seek-baseline.json`):
+
+```bash
+./scripts/run-seek-bench.sh --record
+# or directly:
+BUTTERBAR_RECORD_SEEK_BASELINE=1 swift test \
+  --package-path Packages/PlannerCore \
+  --filter PlannerSeekBenchRecorder
+```
+
+The recorder test is skipped unless `BUTTERBAR_RECORD_SEEK_BASELINE=1` is set, so normal
+`swift test` runs do not touch the baseline file.
+
+## Where the baseline lives
+
+`docs/benchmarks/seek-baseline.json` — committed to the repo. The file records p50, p90,
+and max replay time in milliseconds per fixture, along with the git commit hash and host
+info at recording time.
+
+The baseline reflects the hardware it was recorded on. Numbers will differ across machines;
+the file is advisory, not a hard gate.
+
+## Deferred: regression gate threshold
+
+The `regression_threshold_pct` field in the baseline JSON is currently `null`. Specs
+02/04/05 do not name a numerical seek-to-first-frame SLA. Follow-up issue
+[#107](https://github.com/anonymort/butter-bar/issues/107) (tagged `[opus]`) will define:
+
+- A numerical SLA per fixture
+- A regression threshold percentage for CI
+- Whether to gate PRs on regressions
+
+Until that issue is resolved, the bench is **advisory only** — it does not fail builds.

--- a/docs/benchmarks/seek-baseline.json
+++ b/docs/benchmarks/seek-baseline.json
@@ -1,0 +1,44 @@
+{
+  "fixtures" : {
+    "back-moov-mp4-001" : {
+      "actions" : 9,
+      "events" : 4,
+      "replay_ms_max" : 0.044,
+      "replay_ms_p50" : 0.039,
+      "replay_ms_p90" : 0.041,
+      "samples" : 20
+    },
+    "front-moov-mp4-001" : {
+      "actions" : 9,
+      "events" : 5,
+      "replay_ms_max" : 0.2,
+      "replay_ms_p50" : 0.05,
+      "replay_ms_p90" : 0.053,
+      "samples" : 20
+    },
+    "immediate-seek-001" : {
+      "actions" : 6,
+      "events" : 4,
+      "replay_ms_max" : 0.042,
+      "replay_ms_p50" : 0.039,
+      "replay_ms_p90" : 0.04,
+      "samples" : 20
+    },
+    "mkv-cues-001" : {
+      "actions" : 10,
+      "events" : 5,
+      "replay_ms_max" : 0.063,
+      "replay_ms_p50" : 0.058,
+      "replay_ms_p90" : 0.06,
+      "samples" : 20
+    }
+  },
+  "host" : {
+    "arch" : "arm64",
+    "os_version" : "26.5"
+  },
+  "measured_at" : "2026-04-16T12:42:11Z",
+  "notes" : "Threshold to be set by opus once SLA is defined. Bench currently advisory.",
+  "planner_commit" : "ae8ce81b93f2c7337b73f71d61786c3e73476e1b",
+  "regression_threshold_pct" : null
+}

--- a/scripts/run-seek-bench.sh
+++ b/scripts/run-seek-bench.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Runs the planner seek bench. Use --record to update docs/benchmarks/seek-baseline.json.
+RECORD=0
+for arg in "$@"; do
+  case "$arg" in
+    --record) RECORD=1 ;;
+  esac
+done
+cd "$(dirname "$0")/.."
+if [ "$RECORD" = "1" ]; then
+  BUTTERBAR_RECORD_SEEK_BASELINE=1 swift test --package-path Packages/PlannerCore --filter PlannerSeekBenchRecorder
+  echo "Baseline written to docs/benchmarks/seek-baseline.json"
+else
+  swift test --package-path Packages/PlannerCore --filter PlannerSeekBench
+fi


### PR DESCRIPTION
Closes #105

## Summary

- **`PlannerSeekBenchTests.swift`** — 4 XCTest `measure(metrics: [XCTClockMetric()])` tests, one per trace fixture. Each iteration creates a fresh `DefaultPiecePlanner` + `FakeTorrentSession`, replays all events, and measures wall time. XCTest can store a baseline/stddev once accepted in Xcode UI.
- **`PlannerSeekBenchRecorder.swift`** — Opt-in recorder (requires `BUTTERBAR_RECORD_SEEK_BASELINE=1`). Runs N=20 iterations per fixture, computes p50/p90/max, writes `docs/benchmarks/seek-baseline.json`. Skipped in normal `swift test` runs.
- **`scripts/run-seek-bench.sh`** — Convenience wrapper: `./scripts/run-seek-bench.sh` for the bench, `--record` to update baseline.
- **`docs/benchmarks/README.md`** — Explains what is measured, how to run, and the deferred-SLA caveat.
- **`docs/benchmarks/seek-baseline.json`** — Committed baseline from this machine (arm64, macOS 26.5).
- **`TASKS.md`** — T-PERF-SEEK-BENCH marked DONE.

## Baseline numbers (arm64, macOS 26.5)

| Fixture | Events | Actions | p50 ms | p90 ms | max ms |
|---------|--------|---------|--------|--------|--------|
| front-moov-mp4-001 | 5 | 9 | 0.050 | 0.053 | 0.200 |
| back-moov-mp4-001 | 4 | 9 | 0.039 | 0.041 | 0.044 |
| mkv-cues-001 | 5 | 10 | 0.058 | 0.060 | 0.063 |
| immediate-seek-001 | 4 | 6 | 0.039 | 0.040 | 0.042 |

## Deferred: CI gate + SLA

Specs 02/04/05 do not name a numerical seek-to-first-frame SLA. `regression_threshold_pct` is `null` in the baseline JSON. A follow-up issue (tagged `[opus]`) will define the SLA and gate threshold. Until then the bench is advisory only and does not fail builds.

## Test plan

- [x] `swift test --package-path Packages/PlannerCore` — all 81 existing tests pass, recorder skipped, 4 bench tests pass
- [x] `BUTTERBAR_RECORD_SEEK_BASELINE=1 swift test --package-path Packages/PlannerCore --filter PlannerSeekBenchRecorder` — baseline JSON written, numbers plausible (sub-ms)
- [x] `./scripts/run-seek-bench.sh` — runs bench filter, prints XCTest measurement output
- [x] `./scripts/run-seek-bench.sh --record` — writes baseline JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)