### PR TITLE
[spec] docs: spec 04 — pieceLength gap is mid-play (A21)

### DIFF
--- a/.claude/specs/04-piece-planner.md
+++ b/.claude/specs/04-piece-planner.md
@@ -1,6 +1,6 @@
 # 04 — PiecePlanner
 
-> **Revision 4** — § Seek and § Mid-play GET clarified: "most recently served byte" means `range.end` of most recent GET event processed, not delivered bytes (addendum A20). Rev 3 had expected-actions example rewritten to derive correctly from deadline-spacing rules (addendum A13); § Tick gains explicit `emitHealth` emission rules (addendum A15). Rev 2 introduced "deterministic state machine" language (addendum A3); `.seek` removed from public `PlayerEvent` and derived internally from GET patterns (addendum A4); explicit zero/unknown-rate fallback for deadline spacing added (addendum A5). Baseline revision was rev 1.
+> **Revision 5** — § Mid-play GET clarified: the range `(pieceLength*2, pieceLength*4]` is treated as mid-play, not seek (addendum A21). **Revision 4** — § Seek and § Mid-play GET clarified: "most recently served byte" means `range.end` of most recent GET event processed, not delivered bytes (addendum A20). Rev 3 had expected-actions example rewritten to derive correctly from deadline-spacing rules (addendum A13); § Tick gains explicit `emitHealth` emission rules (addendum A15). Rev 2 introduced "deterministic state machine" language (addendum A3); `.seek` removed from public `PlayerEvent` and derived internally from GET patterns (addendum A4); explicit zero/unknown-rate fallback for deadline spacing added (addendum A5). Baseline revision was rev 1.
 
 The planner is the project's highest-risk component. Build it first, build it deterministic, build it from traces.
 
@@ -125,15 +125,17 @@ On first `get` after `head`:
 
 ### Mid-play GET
 
-On a `get` whose range starts within `pieceLength * 2` of the most recent GET's `range.end` (i.e. sequential):
+On a `get` whose range starts within `pieceLength * 4` of the most recent GET's `range.end` (i.e. sequential or in the gap between sequential and seek thresholds):
 
 1. Confirm covering pieces are still on the deadline list.
 2. Extend the readahead window if it has slipped.
 3. Emit `waitForRange` with `maxWaitMs = 800`.
 
+**Gap clarification:** GETs in the range `(pieceLength*2, pieceLength*4]` are classified as mid-play, not seek. This is the conservative choice — it avoids unnecessary deadline clearing for distances that are close but not clearly a seek (per addendum A21).
+
 ### Seek (internally detected)
 
-When a `get` arrives whose range starts **more than** `pieceLength * 4` away from the most recent GET's `range.end`, the planner classifies it as a seek and:
+When a `get` arrives whose range starts **more than** `pieceLength * 4` away from the most recent GET's `range.end` (i.e. beyond the mid-play and gap windows), the planner classifies it as a seek and:
 
 1. Emits `clearDeadlinesExcept` covering the new window only. Do not keep old deadlines around — they compete for peer slots.
 2. Emits `setDeadlines` for the new window with critical priority on the first 4 pieces (spacing per the deadline-spacing rules above).


### PR DESCRIPTION
Closes #87

## Summary
Spec 04 now explicitly documents that a GET with range.start in the gap `(pieceLength*2, pieceLength*4]` from the most recent GET's `range.end` is classified as mid-play (not seek), per addendum A21. Revision block bumped 4 → 5.

Implementation note: the § Mid-play GET opening threshold was broadened from `pieceLength * 2` to `pieceLength * 4` (so the three mid-play steps now apply across the full mid-play + gap window), and a gap-clarification paragraph was added. § Seek wording tightened to "beyond the mid-play and gap windows".

## Spec refs
- `.claude/specs/00-addendum.md` § A21
- `.claude/specs/04-piece-planner.md` § Mid-play GET; § Seek; Revision block

## Acceptance
- [x] Spec 04 gap handling documented per A21
- [x] Revision block references A21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>