### PR TITLE
fix: library error banner no longer double-stacks prefixes

### DIFF
--- a/App/Features/Library/LibraryView.swift
+++ b/App/Features/Library/LibraryView.swift
@@ -108,7 +108,7 @@ struct LibraryView: View {
     }
 
     private func errorBanner(_ message: String) -> some View {
-        Text("Could not load library: \(message)")
+        Text(message)
             .brandCaption()
             .padding(.horizontal, 12)
             .padding(.vertical, 8)

--- a/App/Features/Library/LibraryViewModel.swift
+++ b/App/Features/Library/LibraryViewModel.swift
@@ -39,7 +39,7 @@ final class LibraryViewModel: ObservableObject {
             torrents = try await engineClient.listTorrents()
             loadError = nil
         } catch {
-            loadError = error.localizedDescription
+            loadError = "Could not load library: \(error.localizedDescription)"
         }
     }
 


### PR DESCRIPTION
Closes #111

## Summary
`LibraryView.errorBanner(_:)` now uses `Text(error)` verbatim instead of prefixing with "Could not load library: …". Each write site (library load, file load, stream open) supplies its own complete, properly-prefixed message. This removes the double-prefix bug ("Could not load library: Could not load files: …").

## Spec refs
- `.claude/specs/06-brand.md` § Voice (messages remain calm/direct)

## Acceptance
- [x] Banner uses `Text(error)` verbatim
- [x] Each error source supplies its own prefix
- [x] Build + snapshot tests green (LibrarySnapshotTests — 4 tests passed, no baselines shifted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>