### PR TITLE
fix: HUD self-hides after 3s without requiring mouse activity

### DIFF
--- a/App/Features/Player/PlayerView.swift
+++ b/App/Features/Player/PlayerView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 /// Wraps `AVPlayerView` (via `AVPlayerViewRepresentable`) and floats
 /// `StreamHealthHUD` over the video at the bottom-centre of the frame.
 ///
-/// The HUD appears on mouse movement and auto-hides after 3 seconds of
-/// inactivity. On first appearance the HUD is visible until the first
-/// mouse movement that starts the timer.
+/// The HUD is visible on first appearance and auto-hides after 3 seconds of
+/// inactivity — even if the mouse never moves. Mouse movement resets the
+/// 3-second timer (existing behaviour).
 struct PlayerView: View {
 
     @StateObject private var viewModel: PlayerViewModel
@@ -66,6 +66,7 @@ struct PlayerView: View {
         }
         .onAppear {
             viewModel.play()
+            scheduleHide()
         }
         .onDisappear {
             hideTask?.cancel()
@@ -77,6 +78,12 @@ struct PlayerView: View {
 
     private func showHUD() {
         hudVisible = true
+        scheduleHide()
+    }
+
+    /// Cancels any pending hide task and starts a new 3-second countdown.
+    /// Called both from `.onAppear` (initial timer) and from `showHUD()` (reset on hover).
+    private func scheduleHide() {
         hideTask?.cancel()
         hideTask = Task {
             do {


### PR DESCRIPTION
Closes #113

## Summary
The player HUD now self-hides after 3 seconds via an `.onAppear`-started timer, so the HUD disappears even if the user never moves the mouse. Extracted timer logic into `scheduleHide()`; `onAppear` and hover handlers both call it. The doc comment at `PlayerView.swift:12-14` is updated to reflect the "auto-hides after 3s of inactivity" invariant.

## Spec refs
- `.claude/specs/06-brand.md` § Motion (HUD fades use slow easeInOut)

## Acceptance
- [x] HUD self-hides after 3s without mouse activity (via `.onAppear` timer)
- [x] Hover still resets the timer (existing behaviour preserved)
- [x] Build green; `PlayerHUDSnapshotTests` green (6 tests — 3 dark pass, 3 light skipped pending #121)

## Manual QA (SwiftUI timer state is not deterministically unit-testable)
1. Open a stream — HUD appears
2. Don't touch the mouse — HUD fades after ~3s
3. Move the mouse — HUD reappears, countdown resets
4. Stop — fades again after 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>