### PR TITLE
refactor: drop unreachable pre-Tahoe #available fallbacks

### DIFF
--- a/App/Features/Player/StreamHealthHUD.swift
+++ b/App/Features/Player/StreamHealthHUD.swift
@@ -157,30 +157,12 @@ struct StreamHealthHUD: View {
 
 // MARK: - HUD surface modifier
 
-/// Applies the correct floating glass surface to the HUD on macOS 26+,
-/// with a `cocoa` 60% opacity fallback for pre-Tahoe SDK builds.
-///
-/// Concern: `.glassEffect(.regular.interactive())` is macOS 26+. The
-/// fallback (`.ultraThinMaterial` + opaque tint) approximates the effect
-/// but will not pick up tint from the video underneath. Since the v1
-/// deployment target is macOS 26 (Xcode 26 SDK), the fallback path
-/// should not ship, but is kept so the project builds cleanly if the
-/// SDK is temporarily downgraded during development.
 private extension View {
-    @ViewBuilder
     func hudSurface() -> some View {
-        if #available(macOS 26, *) {
-            // Glass picks up tint from underlying video content, per spec 06.
-            self
-                .glassEffect(.regular.interactive())
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        } else {
-            // Pre-Tahoe fallback — does not reach production in v1.
-            self
-                .background(BrandColors.cocoa.opacity(0.6))
-                .background(.ultraThinMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        }
+        // Glass picks up tint from underlying video content, per spec 06.
+        self
+            .glassEffect(.regular.interactive())
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 }
 


### PR DESCRIPTION
Closes #114

## Summary
- Removed the single `if #available(macOS 26, *)` guard in `StreamHealthHUD.swift:172` and its dead else branch (`ultraThinMaterial` + `cocoa.opacity(0.6)` fallback), keeping only `.glassEffect(.regular.interactive())`.
- Dropped `@ViewBuilder` (single return path, no longer needed).
- Removed the stale doc comment that described the now-gone fallback.
- No other pre-Tahoe availability guards found across `App/`, `EngineService/`, or `Packages/`.

## Spec refs
- `.claude/specs/09-platform-tahoe.md` § Deployment target
- `.claude/specs/00-addendum.md` A18

## Acceptance
- [x] `grep -rn "#available(macOS 2[6-9]" App EngineService Packages` returns zero matches
- [x] Both Xcode schemes build (`BUILD SUCCEEDED`)
- [x] `PlayerHUDSnapshotTests` unchanged (6 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>