### PR TITLE
refactor: introduce BrandColors.videoLetterbox token

### DIFF
--- a/App/Brand/BrandColors.swift
+++ b/App/Brand/BrandColors.swift
@@ -41,4 +41,14 @@ enum BrandColors {
     static let surfaceRaised  = creamRaised
     /// Modal scrims, popovers without glass treatment.
     static let surfaceOverlay: Color = cocoa.opacity(0.4)
+
+    // MARK: - Player tokens
+
+    /// Fill behind the video frame (letterbox / pillarbox bars).
+    ///
+    /// Always pure black regardless of system appearance. Video content is
+    /// colour-managed and must be surrounded by absolute black — not a
+    /// warm cream or a near-black — so that the perceived contrast and
+    /// colour accuracy of the image are unaffected by the surrounding surface.
+    static let videoLetterbox = Color.black
 }

--- a/App/Features/Player/PlayerView.swift
+++ b/App/Features/Player/PlayerView.swift
@@ -28,7 +28,7 @@ struct PlayerView: View {
     var body: some View {
         ZStack {
             // Solid black behind the video — always dark regardless of system theme.
-            Color.black
+            BrandColors.videoLetterbox
                 .ignoresSafeArea()
 
             if let player = viewModel.player {

--- a/App/Features/Player/StreamHealthHUD.swift
+++ b/App/Features/Player/StreamHealthHUD.swift
@@ -184,7 +184,7 @@ private extension View {
     ))
     .preferredColorScheme(.dark)
     .padding()
-    .background(Color.black)
+    .background(BrandColors.videoLetterbox)
 }
 
 #Preview("HUD — marginal, dark") {
@@ -200,7 +200,7 @@ private extension View {
     ))
     .preferredColorScheme(.dark)
     .padding()
-    .background(Color.black)
+    .background(BrandColors.videoLetterbox)
 }
 
 #Preview("HUD — starving, dark") {
@@ -216,5 +216,5 @@ private extension View {
     ))
     .preferredColorScheme(.dark)
     .padding()
-    .background(Color.black)
+    .background(BrandColors.videoLetterbox)
 }


### PR DESCRIPTION
Closes #116

## Summary
- Added `BrandColors.videoLetterbox` (always-black) in `App/Brand/BrandColors.swift` with a doc comment explaining the colour-accuracy invariant: video must be surrounded by absolute black so the image's perceived contrast and colour fidelity are unaffected by the surrounding surface.
- Replaced `Color.black` at `PlayerView.swift:31` (production letterbox fill behind AVPlayer).
- Also replaced three `Color.black` preview backgrounds in `StreamHealthHUD.swift` (all simulate the same dark player surround — same semantic as the token).

## Spec refs
- `.claude/specs/06-brand.md` § Colour palette

## Acceptance
- [x] `BrandColors.videoLetterbox` exists with doc comment
- [x] `PlayerView.swift` uses the token
- [x] No behavioural change (pixel output identical)
- [x] Build green; snapshot tests status unchanged (all 6 HUD tests still skipped pending #121)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>