### PR TITLE
fix: add pieceIndex field to piece_finished_alert dict in TorrentBridge

### DIFF
--- a/ButterBar.xcodeproj/project.pbxproj
+++ b/ButterBar.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		F3A4B5C6D7E8F3A4B5C6D7E8 /* RealTorrentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E9F0A1B2C3D8E9F0A1B2C3 /* RealTorrentSession.swift */; };
 		F4249ADDF3CC568FD40A915F /* BrandTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85244C3556DDB6DB1831AAB0 /* BrandTypography.swift */; };
 		F9F417F62F912246005E8A2B /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = F9F417F52F912246005E8A2B /* AppIcon.icon */; };
+		TA000002000000000000AA01 /* TorrentAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TA000001000000000000BB01 /* TorrentAlertTests.swift */; };
+		TA000003000000000000AA01 /* TorrentAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C4D5E6F7A8B3C4D5E6F7A8 /* TorrentAlert.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +101,7 @@
 
 /* Begin PBXFileReference section */
 		1081C8A3D05554F25364C74A /* EngineService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EngineService.entitlements; sourceTree = "<group>"; };
+		TA000001000000000000BB01 /* TorrentAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentAlertTests.swift; sourceTree = "<group>"; };
 		1785E418002BEE10CA7FEDC0 /* TestFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TestFixtures; path = Packages/TestFixtures; sourceTree = "<group>"; };
 		39AB853C8253F0485E14495A /* EngineInterface */ = {isa = PBXFileReference; lastKnownFileType = folder; name = EngineInterface; path = Packages/EngineInterface; sourceTree = "<group>"; };
 		3A4B5C6D7E8F3A4B5C6D7E8F /* ButterBarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ButterBarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -239,6 +242,7 @@
 			children = (
 				EB3FC12896B9622317749428 /* LibrarySnapshotTests.swift */,
 				B1000005000000000000BB05 /* PlayerHUDSnapshotTests.swift */,
+				TA000001000000000000BB01 /* TorrentAlertTests.swift */,
 			);
 			path = ButterBarTests;
 			sourceTree = "<group>";
@@ -552,6 +556,8 @@
 			files = (
 				7733C28EE8BA53BDB56B8824 /* LibrarySnapshotTests.swift in Sources */,
 				A1000005000000000000AA05 /* PlayerHUDSnapshotTests.swift in Sources */,
+				TA000002000000000000AA01 /* TorrentAlertTests.swift in Sources */,
+				TA000003000000000000AA01 /* TorrentAlert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EngineService/Bridge/TorrentAlert.swift
+++ b/EngineService/Bridge/TorrentAlert.swift
@@ -29,7 +29,8 @@ enum TorrentAlert {
         case "stats_alert", "status_notification_alert":
             return .statsUpdated(torrentID: torrentID ?? "")
         case "piece_finished_alert":
-            return .pieceFinished(torrentID: torrentID ?? "", pieceIndex: extractPieceIndex(from: message))
+            let pieceIndex = (dict["pieceIndex"] as? Int) ?? -1
+            return .pieceFinished(torrentID: torrentID ?? "", pieceIndex: pieceIndex)
         case "metadata_received_alert":
             return .metadataReceived(torrentID: torrentID ?? "")
         case "torrent_finished_alert":
@@ -39,15 +40,5 @@ enum TorrentAlert {
         default:
             return .unknown(type: type, message: message)
         }
-    }
-
-    // libtorrent piece_finished_alert message contains the piece index as a decimal number.
-    // Returns -1 if no integer can be parsed.
-    private static func extractPieceIndex(from message: String) -> Int {
-        let components = message.components(separatedBy: CharacterSet.decimalDigits.inverted)
-        for component in components where !component.isEmpty {
-            if let index = Int(component) { return index }
-        }
-        return -1
     }
 }

--- a/Tests/ButterBarTests/TorrentAlertTests.swift
+++ b/Tests/ButterBarTests/TorrentAlertTests.swift
@@ -1,0 +1,96 @@
+// TorrentAlert.swift is compiled directly into this test target (no module import needed).
+// It lives at EngineService/Bridge/TorrentAlert.swift and is referenced via the
+// ButterBarTests Sources build phase in project.pbxproj.
+
+import XCTest
+
+final class TorrentAlertParsingTests: XCTestCase {
+
+    // MARK: - piece_finished_alert: dict-based pieceIndex
+
+    func testPieceFinished_readsPieceIndexFromDict() {
+        let dict: NSDictionary = [
+            "type": "piece_finished_alert",
+            "torrentID": "abc-123",
+            "message": "piece finished",
+            "pieceIndex": NSNumber(value: 42),
+        ]
+        let alert = TorrentAlert.from(dict)
+        guard case .pieceFinished(let tid, let idx) = alert else {
+            XCTFail("Expected .pieceFinished, got \(alert)")
+            return
+        }
+        XCTAssertEqual(tid, "abc-123")
+        XCTAssertEqual(idx, 42)
+    }
+
+    func testPieceFinished_pieceIndexZero() {
+        let dict: NSDictionary = [
+            "type": "piece_finished_alert",
+            "torrentID": "t-zero",
+            "message": "piece finished",
+            "pieceIndex": NSNumber(value: 0),
+        ]
+        if case .pieceFinished(_, let idx) = TorrentAlert.from(dict) {
+            XCTAssertEqual(idx, 0)
+        } else {
+            XCTFail("Expected .pieceFinished")
+        }
+    }
+
+    func testPieceFinished_largeIndex() {
+        let dict: NSDictionary = [
+            "type": "piece_finished_alert",
+            "torrentID": "t-large",
+            "message": "piece finished",
+            "pieceIndex": NSNumber(value: 99_999),
+        ]
+        if case .pieceFinished(_, let idx) = TorrentAlert.from(dict) {
+            XCTAssertEqual(idx, 99_999)
+        } else {
+            XCTFail("Expected .pieceFinished")
+        }
+    }
+
+    func testPieceFinished_missingPieceIndex_fallsBackToMinusOne() {
+        // pieceIndex absent — bridge contract violation; we return -1 as sentinel.
+        let dict: NSDictionary = [
+            "type": "piece_finished_alert",
+            "torrentID": "t-missing",
+            "message": "piece finished",
+        ]
+        if case .pieceFinished(_, let idx) = TorrentAlert.from(dict) {
+            XCTAssertEqual(idx, -1)
+        } else {
+            XCTFail("Expected .pieceFinished")
+        }
+    }
+
+    // MARK: - Other alert types unaffected
+
+    func testStateChanged_unaffected() {
+        let dict: NSDictionary = [
+            "type": "state_changed_alert",
+            "torrentID": "t-x",
+            "message": "downloading",
+        ]
+        if case .stateChanged(let tid, let state) = TorrentAlert.from(dict) {
+            XCTAssertEqual(tid, "t-x")
+            XCTAssertEqual(state, "downloading")
+        } else {
+            XCTFail("Expected .stateChanged")
+        }
+    }
+
+    func testUnknown_unaffected() {
+        let dict: NSDictionary = [
+            "type": "some_unknown_alert",
+            "message": "whatever",
+        ]
+        if case .unknown(let type, _) = TorrentAlert.from(dict) {
+            XCTAssertEqual(type, "some_unknown_alert")
+        } else {
+            XCTFail("Expected .unknown")
+        }
+    }
+}


### PR DESCRIPTION
Closes #89

## Summary
`TorrentBridge.mm` `_drainAlerts` already copied `pfa->piece_index` into `dict["pieceIndex"]` for every `piece_finished_alert` (verified on inspection — the issue description was partly stale). `TorrentAlert.from(_:)` now reads from the dict instead of parsing the fragile message string. `extractPieceIndex(from:)` removed (no other call sites, confirmed via grep).

Added `TorrentAlertParsingTests` (6 cases) covering pieceIndex round-trip with various values, missing-key sentinel fallback (-1), and unaffected alert types (stateChanged, unknown).

## Spec refs
- `.claude/specs/01-architecture.md` § TorrentBridge

## Acceptance
- [x] `dict["pieceIndex"]` populated in `_drainAlerts` (was already; verified)
- [x] `TorrentAlert.from` reads from dict
- [x] `extractPieceIndex(from:)` removed (no other callers)
- [x] Round-trip test passes (6/6)
- [x] Both schemes build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>