### PR TITLE
fix: populate FileAvailabilityDTO.availableRanges from piece bitmap

### DIFF
--- a/ButterBar.xcodeproj/project.pbxproj
+++ b/ButterBar.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		F9F417F62F912246005E8A2B /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = F9F417F52F912246005E8A2B /* AppIcon.icon */; };
 		TA000002000000000000AA01 /* TorrentAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TA000001000000000000BB01 /* TorrentAlertTests.swift */; };
 		TA000003000000000000AA01 /* TorrentAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C4D5E6F7A8B3C4D5E6F7A8 /* TorrentAlert.swift */; };
+		PBM00001000000000000AA01 /* PieceByteMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = PBM00002000000000000BB01 /* PieceByteMapping.swift */; };
+		PBM00003000000000000AA01 /* PieceByteMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = PBM00002000000000000BB01 /* PieceByteMapping.swift */; };
+		PBM00004000000000000AA01 /* PieceByteMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PBM00005000000000000BB01 /* PieceByteMappingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +105,8 @@
 /* Begin PBXFileReference section */
 		1081C8A3D05554F25364C74A /* EngineService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EngineService.entitlements; sourceTree = "<group>"; };
 		TA000001000000000000BB01 /* TorrentAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentAlertTests.swift; sourceTree = "<group>"; };
+		PBM00002000000000000BB01 /* PieceByteMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceByteMapping.swift; sourceTree = "<group>"; };
+		PBM00005000000000000BB01 /* PieceByteMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceByteMappingTests.swift; sourceTree = "<group>"; };
 		1785E418002BEE10CA7FEDC0 /* TestFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TestFixtures; path = Packages/TestFixtures; sourceTree = "<group>"; };
 		39AB853C8253F0485E14495A /* EngineInterface */ = {isa = PBXFileReference; lastKnownFileType = folder; name = EngineInterface; path = Packages/EngineInterface; sourceTree = "<group>"; };
 		3A4B5C6D7E8F3A4B5C6D7E8F /* ButterBarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ButterBarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -243,6 +248,7 @@
 				EB3FC12896B9622317749428 /* LibrarySnapshotTests.swift */,
 				B1000005000000000000BB05 /* PlayerHUDSnapshotTests.swift */,
 				TA000001000000000000BB01 /* TorrentAlertTests.swift */,
+				PBM00005000000000000BB01 /* PieceByteMappingTests.swift */,
 			);
 			path = ButterBarTests;
 			sourceTree = "<group>";
@@ -338,6 +344,7 @@
 				D8E9F0A1B2C3D8E9F0A1B2C3 /* RealTorrentSession.swift */,
 				B3C4D5E6F7A8B3C4D5E6F7A8 /* TorrentAlert.swift */,
 				D5E6F7A8B9C0D5E6F7A8B9C0 /* AlertDispatcher.swift */,
+				PBM00002000000000000BB01 /* PieceByteMapping.swift */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -558,6 +565,8 @@
 				A1000005000000000000AA05 /* PlayerHUDSnapshotTests.swift in Sources */,
 				TA000002000000000000AA01 /* TorrentAlertTests.swift in Sources */,
 				TA000003000000000000AA01 /* TorrentAlert.swift in Sources */,
+				PBM00003000000000000AA01 /* PieceByteMapping.swift in Sources */,
+				PBM00004000000000000AA01 /* PieceByteMappingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -576,6 +585,7 @@
 				F3A4B5C6D7E8F3A4B5C6D7E8 /* RealTorrentSession.swift in Sources */,
 				A2B3C4D5E6F7A2B3C4D5E6F7 /* TorrentAlert.swift in Sources */,
 				C4D5E6F7A8B9C4D5E6F7A8B9 /* AlertDispatcher.swift in Sources */,
+				PBM00001000000000000AA01 /* PieceByteMapping.swift in Sources */,
 				D6E7F8A9B0C1D6E7F8A9B0C1 /* GatewayListener.swift in Sources */,
 				F2A3B4C5D6E7F2A3B4C5D6E7 /* ByteReader.swift in Sources */,
 				AA11223344556677AABB1122 /* HTTPTypes.swift in Sources */,

--- a/EngineService/Bridge/AlertDispatcher.swift
+++ b/EngineService/Bridge/AlertDispatcher.swift
@@ -85,18 +85,55 @@ final class AlertDispatcher {
     }
 
     private func emitFileAvailabilityChanged(torrentID: String, to proxy: EngineEvents) {
-        guard (try? bridge.havePieces(torrentID)) != nil else {
+        let havePiecesArray: [NSNumber]
+        do {
+            havePiecesArray = try bridge.havePieces(torrentID)
+        } catch {
             NSLog("[AlertDispatcher] havePieces failed for %@", torrentID)
             return
         }
 
-        // Full file→piece range mapping is deferred to the gateway wiring task.
-        // Emit a minimal DTO so the event type flows end-to-end.
-        let dto = FileAvailabilityDTO(
-            torrentID: torrentID as NSString,
-            fileIndex: 0,
-            availableRanges: []
-        )
-        proxy.fileAvailabilityChanged(dto)
+        let pieceLength = bridge.pieceLength(torrentID)
+        guard pieceLength > 0 else {
+            NSLog("[AlertDispatcher] pieceLength unavailable for %@", torrentID)
+            return
+        }
+
+        let havePieces = havePiecesArray.map { $0.intValue }
+
+        let files: [NSDictionary]
+        do {
+            files = try bridge.listFiles(torrentID) as? [NSDictionary] ?? []
+        } catch {
+            NSLog("[AlertDispatcher] listFiles failed for %@", torrentID)
+            return
+        }
+
+        for file in files {
+            guard let fileIndex = (file["index"] as? NSNumber)?.int32Value else { continue }
+
+            var fileStart: Int64 = 0
+            var fileEnd:   Int64 = 0
+            do {
+                try bridge.fileByteRange(torrentID, fileIndex: fileIndex, start: &fileStart, end: &fileEnd)
+            } catch {
+                NSLog("[AlertDispatcher] fileByteRange failed for %@ file %d", torrentID, fileIndex)
+                continue
+            }
+
+            let ranges = PieceByteMapping.availableRanges(
+                havePieces: havePieces,
+                pieceLength: pieceLength,
+                fileStart: fileStart,
+                fileEnd: fileEnd
+            )
+
+            let dto = FileAvailabilityDTO(
+                torrentID: torrentID as NSString,
+                fileIndex: fileIndex,
+                availableRanges: ranges
+            )
+            proxy.fileAvailabilityChanged(dto)
+        }
     }
 }

--- a/EngineService/Bridge/PieceByteMapping.swift
+++ b/EngineService/Bridge/PieceByteMapping.swift
@@ -1,0 +1,80 @@
+import Foundation
+import EngineInterface
+
+/// Pure functions for mapping torrent piece indices to file-relative byte ranges.
+///
+/// All inputs are value types or primitives — no bridge calls, no I/O, no clocks.
+/// This makes the logic trivially testable with synthetic bitmaps.
+enum PieceByteMapping {
+
+    /// Maps a set of downloaded piece indices to coalesced file-relative byte ranges.
+    ///
+    /// - Parameters:
+    ///   - havePieces: Piece indices that are fully downloaded (any order, may contain duplicates).
+    ///   - pieceLength: Uniform piece size in bytes (from `TorrentBridge.pieceLength`).
+    ///   - fileStart: Torrent-absolute byte offset of the first byte of the file.
+    ///   - fileEnd: Torrent-absolute exclusive end offset (one past the last byte of the file).
+    /// - Returns: Sorted, coalesced `ByteRangeDTO` entries in file-relative coordinates,
+    ///   with both `startByte` and `endByte` inclusive.
+    ///   Returns an empty array when `havePieces` is empty, `pieceLength` is zero,
+    ///   or no downloaded piece intersects the file.
+    static func availableRanges(
+        havePieces: [Int],
+        pieceLength: Int64,
+        fileStart: Int64,
+        fileEnd: Int64
+    ) -> [ByteRangeDTO] {
+        guard pieceLength > 0, fileEnd > fileStart, !havePieces.isEmpty else { return [] }
+
+        let firstFilePiece = Int(fileStart / pieceLength)
+        let lastFilePiece  = Int((fileEnd - 1) / pieceLength)
+
+        // Filter to pieces that overlap this file and sort.
+        let relevant = havePieces
+            .filter { $0 >= firstFilePiece && $0 <= lastFilePiece }
+            .sorted()
+
+        guard !relevant.isEmpty else { return [] }
+
+        // Convert each piece to its torrent-absolute byte interval, then clamp to
+        // the file's byte range, then convert to file-relative coordinates.
+        var ranges: [ByteRangeDTO] = []
+        var runStart: Int64? = nil
+        var runEnd:   Int64? = nil
+
+        for piece in relevant {
+            let pieceAbsStart = Int64(piece) * pieceLength
+            let pieceAbsEnd   = pieceAbsStart + pieceLength  // exclusive
+
+            // Clamp to file boundaries (torrent-absolute).
+            let clampedAbsStart = max(pieceAbsStart, fileStart)
+            let clampedAbsEnd   = min(pieceAbsEnd,   fileEnd)   // exclusive
+
+            guard clampedAbsEnd > clampedAbsStart else { continue }
+
+            // File-relative, inclusive on both ends.
+            let relStart = clampedAbsStart - fileStart
+            let relEnd   = clampedAbsEnd   - fileStart - 1
+
+            if let rs = runStart, let re = runEnd {
+                // Coalesce: adjacent means relStart == re + 1.
+                if relStart <= re + 1 {
+                    runEnd = max(re, relEnd)
+                } else {
+                    ranges.append(ByteRangeDTO(startByte: rs, endByte: re))
+                    runStart = relStart
+                    runEnd   = relEnd
+                }
+            } else {
+                runStart = relStart
+                runEnd   = relEnd
+            }
+        }
+
+        if let rs = runStart, let re = runEnd {
+            ranges.append(ByteRangeDTO(startByte: rs, endByte: re))
+        }
+
+        return ranges
+    }
+}

--- a/Tests/ButterBarTests/PieceByteMappingTests.swift
+++ b/Tests/ButterBarTests/PieceByteMappingTests.swift
@@ -1,0 +1,169 @@
+// PieceByteMapping.swift is compiled directly into this test target.
+// It lives at EngineService/Bridge/PieceByteMapping.swift and is referenced via
+// the ButterBarTests Sources build phase in project.pbxproj.
+
+import XCTest
+import EngineInterface
+
+// MARK: - Helpers
+
+private func ranges(
+    pieces: [Int],
+    pieceLength: Int64,
+    fileStart: Int64,
+    fileEnd: Int64
+) -> [(start: Int64, end: Int64)] {
+    PieceByteMapping.availableRanges(
+        havePieces: pieces,
+        pieceLength: pieceLength,
+        fileStart: fileStart,
+        fileEnd: fileEnd
+    ).map { ($0.startByte, $0.endByte) }
+}
+
+final class PieceByteMappingTests: XCTestCase {
+
+    // MARK: - Empty bitmap
+
+    func testEmpty_noPieces_returnsEmpty() {
+        let result = ranges(pieces: [], pieceLength: 256_000, fileStart: 0, fileEnd: 1_000_000)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Single piece
+
+    func testSinglePiece_firstPiece_fileStartsAtZero() {
+        // File covers [0, 512000), piece length 256000.
+        // Piece 0 → torrent abs [0, 256000), file-relative [0, 255999] inclusive.
+        let result = ranges(pieces: [0], pieceLength: 256_000, fileStart: 0, fileEnd: 512_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 255_999)
+    }
+
+    func testSinglePiece_middleOfFile() {
+        // File covers torrent abs [100_000, 900_000). Piece length 256_000.
+        // File spans pieces 0..2 (piece 0: [0,256000), piece 1: [256000,512000), piece 2: [512000,768000)).
+        // havePieces = [1] → intersect with file → clamp → file-relative.
+        // piece 1 abs [256000, 512000), clamped to file [100000, 900000) → [256000, 512000).
+        // file-relative: start = 256000-100000 = 156000, end = 512000-100000-1 = 411999.
+        let result = ranges(pieces: [1], pieceLength: 256_000, fileStart: 100_000, fileEnd: 900_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 156_000)
+        XCTAssertEqual(result[0].end, 411_999)
+    }
+
+    // MARK: - Contiguous run
+
+    func testContiguousRun_coalescesIntoSingleRange() {
+        // File [0, 768000), piece length 256000. Pieces 0,1,2 all present.
+        // Should coalesce to single range [0, 767999].
+        let result = ranges(pieces: [0, 1, 2], pieceLength: 256_000, fileStart: 0, fileEnd: 768_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 767_999)
+    }
+
+    func testContiguousRun_unsortedInput_coalescesCorrectly() {
+        let result = ranges(pieces: [2, 0, 1], pieceLength: 256_000, fileStart: 0, fileEnd: 768_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 767_999)
+    }
+
+    // MARK: - Scattered pieces (gap in middle)
+
+    func testScatteredPieces_producesMultipleRanges() {
+        // File [0, 1_024_000), piece length 256_000. Pieces 0 and 3 (gap at 1 and 2).
+        // Piece 0 → [0, 255999], piece 3 → [768000, 1023999].
+        let result = ranges(pieces: [0, 3], pieceLength: 256_000, fileStart: 0, fileEnd: 1_024_000)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 255_999)
+        XCTAssertEqual(result[1].start, 768_000)
+        XCTAssertEqual(result[1].end, 1_023_999)
+    }
+
+    func testScatteredPieces_firstAndLast_twoRanges() {
+        // File [0, 768000), pieces 0 and 2, gap at 1.
+        let result = ranges(pieces: [0, 2], pieceLength: 256_000, fileStart: 0, fileEnd: 768_000)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 255_999)
+        XCTAssertEqual(result[1].start, 512_000)
+        XCTAssertEqual(result[1].end, 767_999)
+    }
+
+    // MARK: - All pieces
+
+    func testAllPieces_singleRange_coveringWholeFile() {
+        let result = ranges(pieces: [0, 1, 2, 3], pieceLength: 256_000, fileStart: 0, fileEnd: 1_024_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 1_023_999)
+    }
+
+    // MARK: - Last piece file-end truncation
+
+    func testLastPiece_truncatedToFileEnd() {
+        // File [0, 300_000): doesn't end on a piece boundary (piece length 256_000).
+        // Piece 0 covers [0, 256000), piece 1 covers [256000, 512000) but file only goes to 300000.
+        // Last piece (1) should be clamped: file-relative [256000, 299999].
+        let result = ranges(pieces: [0, 1], pieceLength: 256_000, fileStart: 0, fileEnd: 300_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 299_999)
+    }
+
+    func testLastPiece_onlyLastPiecePresent_truncated() {
+        // File [0, 300_000), only piece 1 downloaded.
+        // Piece 1 abs [256000, 512000) clamped to [256000, 300000), file-relative [256000, 299999].
+        let result = ranges(pieces: [1], pieceLength: 256_000, fileStart: 0, fileEnd: 300_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 256_000)
+        XCTAssertEqual(result[0].end, 299_999)
+    }
+
+    // MARK: - File does not start at zero (multi-file torrent offset)
+
+    func testFileNotAtTorrentStart_singlePiece() {
+        // File starts at torrent offset 512_000, length 256_000 → fileEnd = 768_000.
+        // Piece length 256_000. Piece 2 covers torrent abs [512000, 768000).
+        // Clamped to file → same. File-relative: [0, 255999].
+        let result = ranges(pieces: [2], pieceLength: 256_000, fileStart: 512_000, fileEnd: 768_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 255_999)
+    }
+
+    func testFileNotAtTorrentStart_pieceOutsideFile_excluded() {
+        // Only piece 0 downloaded, but file starts at 512_000. Piece 0 doesn't overlap.
+        let result = ranges(pieces: [0], pieceLength: 256_000, fileStart: 512_000, fileEnd: 768_000)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Edge: zero piece length guard
+
+    func testZeroPieceLength_returnsEmpty() {
+        let result = ranges(pieces: [0, 1, 2], pieceLength: 0, fileStart: 0, fileEnd: 1_000_000)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Edge: empty file range guard
+
+    func testEmptyFileRange_returnsEmpty() {
+        // fileStart == fileEnd → zero-length file.
+        let result = ranges(pieces: [0], pieceLength: 256_000, fileStart: 100, fileEnd: 100)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Duplicate pieces in input
+
+    func testDuplicatePieces_treatedCorrectly() {
+        // Duplicates should not produce duplicate ranges after sort+coalesce.
+        let result = ranges(pieces: [0, 0, 1, 1], pieceLength: 256_000, fileStart: 0, fileEnd: 512_000)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 511_999)
+    }
+}


### PR DESCRIPTION
Closes #90

## Summary
- `AlertDispatcher.emitFileAvailabilityChanged` now computes `availableRanges` from the torrent's piece bitmap: it queries `havePieces`, iterates all files via `listFiles`, maps each downloaded piece to its byte range within each file (clamped to `fileByteRange`), and coalesces adjacent ranges into `ByteRangeDTO` entries. One `FileAvailabilityDTO` is emitted per file, supporting multi-file torrents.
- Pure coalesce logic lives in a new `PieceByteMapping` enum (`EngineService/Bridge/PieceByteMapping.swift`) — no bridge calls, no I/O, trivially testable. `ByteReader.swift` already had the piece↔byte arithmetic but is scoped to a single-file reader; `PieceByteMapping` handles the general case cleanly without reuse friction.
- 15 unit tests added in `PieceByteMappingTests.swift` covering all specified edge cases.

## Spec refs
- `.claude/specs/03-xpc-contract.md` § DTOs
- `.claude/specs/04-piece-planner.md` (piece↔byte conventions)

## Acceptance
- [x] `availableRanges` populated from `havePieces`
- [x] Piece byte ranges clamped to file byte range
- [x] Adjacent pieces coalesced
- [x] Unit tests cover edge cases (15 tests, all passing)
- [x] Both schemes build (`BUILD SUCCEEDED`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>