### PR TITLE
fix(ci): disable signing for snapshot test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,19 @@ jobs:
         run: echo "CI scaffolded; actual build steps come online with T-REPO-INIT."
 
       - name: Snapshot tests
+        # CI runners don't have the owner's personal signing certificate for
+        # team 6633CLRXPK (set in 1483bcc). Disable signing for this step —
+        # safe because nothing is being distributed. Local developer builds
+        # still sign normally via project-level DEVELOPMENT_TEAM.
         run: |
           xcodebuild test \
             -scheme ButterBar \
             -only-testing:ButterBarTests/LibrarySnapshotTests \
             -only-testing:ButterBarTests/PlayerHUDSnapshotTests \
-            -destination 'platform=macOS'
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
 
   link-check:
     name: PR must link an issue


### PR DESCRIPTION
Closes #135

## Summary
CI runners don't have the personal team 6633CLRXPK signing certificate set in `1483bcc chore(xcode): set DEVELOPMENT_TEAM`. Every PR since #120 (which added the `Snapshot tests` step) has gone red on that step because `xcodebuild test` now requires signing.

Fix: pass `CODE_SIGN_IDENTITY=""`, `CODE_SIGNING_REQUIRED=NO`, `CODE_SIGNING_ALLOWED=NO` on the CI invocation. Adhoc / no-signing is safe for a test run — nothing is being distributed. Project-level `DEVELOPMENT_TEAM` stays for local developer builds.

## Verification
Locally:
```
xcodebuild test -scheme ButterBar ... CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
** TEST SUCCEEDED **
```

## Acceptance
- [x] `.github/workflows/ci.yml` Snapshot-tests step passes `CODE_SIGN_*` overrides
- [x] Local unsigned build + test succeeds
- [ ] CI green on this PR itself (will verify post-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>