### PR TITLE
fix(ci): install libtorrent on runner; de-pin versioned Cellar paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Placeholder
         run: echo "CI scaffolded; actual build steps come online with T-REPO-INIT."
 
+      - name: Install libtorrent-rasterbar
+        run: |
+          brew update
+          brew install libtorrent-rasterbar
+          # Verify the opt/ symlink exists for consistent include paths
+          ls /opt/homebrew/opt/libtorrent-rasterbar/include/libtorrent/session.hpp
+
       - name: Snapshot tests
         # CI runners don't have the owner's personal signing certificate for
         # team 6633CLRXPK (set in 1483bcc). Disable signing for this step —

--- a/ButterBar.xcodeproj/project.pbxproj
+++ b/ButterBar.xcodeproj/project.pbxproj
@@ -855,7 +855,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/opt/homebrew/include,
-					"/opt/homebrew/Cellar/libtorrent-rasterbar/2.0.12/include",
+					"/opt/homebrew/opt/libtorrent-rasterbar/include",
 					"/opt/homebrew/opt/openssl@3/include",
 				);
 				INFOPLIST_FILE = EngineService/Info.plist;
@@ -867,7 +867,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					/opt/homebrew/lib,
-					"/opt/homebrew/Cellar/libtorrent-rasterbar/2.0.12/lib",
+					"/opt/homebrew/opt/libtorrent-rasterbar/lib",
 					"/opt/homebrew/opt/openssl@3/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
@@ -1138,7 +1138,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/opt/homebrew/include,
-					"/opt/homebrew/Cellar/libtorrent-rasterbar/2.0.12/include",
+					"/opt/homebrew/opt/libtorrent-rasterbar/include",
 					"/opt/homebrew/opt/openssl@3/include",
 				);
 				INFOPLIST_FILE = EngineService/Info.plist;
@@ -1150,7 +1150,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					/opt/homebrew/lib,
-					"/opt/homebrew/Cellar/libtorrent-rasterbar/2.0.12/lib",
+					"/opt/homebrew/opt/libtorrent-rasterbar/lib",
 					"/opt/homebrew/opt/openssl@3/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;


### PR DESCRIPTION
Closes #137

## Summary
After PR #136 removed the signing blocker, CI still fails at the `Snapshot tests` step because libtorrent-rasterbar isn't installed on GitHub-hosted runners and the Xcode project pins include/library paths to `Cellar/libtorrent-rasterbar/2.0.12/...`.

Two changes:
1. Add a `brew install libtorrent-rasterbar` step in `.github/workflows/ci.yml` before the Snapshot tests step.
2. Replace versioned Cellar paths in `project.pbxproj` with `/opt/homebrew/opt/libtorrent-rasterbar/{include,lib}` (the `opt/` symlink auto-tracks the current Homebrew version). Prevents silent CI breakage when Homebrew ships 2.0.13+.

## Verification
- Local: both Xcode schemes build cleanly with the depinned paths (local system has the brew symlink).
- CI: pending this PR's own run.

## Spec refs
- None (build-infrastructure)

## Acceptance
- [x] `brew install libtorrent-rasterbar` step added to CI
- [x] `grep -c "Cellar/libtorrent-rasterbar/2.0.12" ButterBar.xcodeproj/project.pbxproj` returns 0 (4 → 0)
- [x] Local builds succeed with depinned paths
- [ ] CI Snapshot tests step green (verify post-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>