### PR TITLE
fix: re-capture [weak self] inside Task closures for Swift 6 strict concurrency

### DIFF
--- a/App/Shared/EngineClient.swift
+++ b/App/Shared/EngineClient.swift
@@ -103,11 +103,14 @@ public actor EngineClient {
         conn.setCodeSigningRequirement(engineServiceCodeSigningRequirement)
 
         // Capture self weakly so these closures don't keep the actor alive.
+        // Re-capture `[weak self]` inside the inner Task so Swift 6 strict
+        // concurrency can prove the hop across isolation boundaries is safe
+        // (the outer closure is a `sending` parameter).
         conn.invalidationHandler = { [weak self] in
-            Task { await self?.handleInvalidation() }
+            Task { [weak self] in await self?.handleInvalidation() }
         }
         conn.interruptionHandler = { [weak self] in
-            Task { await self?.handleInterruption() }
+            Task { [weak self] in await self?.handleInterruption() }
         }
 
         conn.resume()


### PR DESCRIPTION
Closes #139

## Summary
CI's Xcode 26.2 / Swift 6 rejects the existing `{ [weak self] in Task { await self?.x() } }` pattern — the `Task.init` initialiser takes a `sending` closure and the compiler cannot prove the isolation-boundary hop is safe when `self` is captured weakly in the outer closure. Local Xcode 26.5 accepts it.

Fix: re-capture `[weak self]` INSIDE the inner Task body. This makes the hop explicit and compiles under both strict (CI) and relaxed (local) concurrency settings. No behavioural change — retention semantics are identical.

## Spec refs
- None (build/toolchain fix)

## Acceptance
- [x] Local build green
- [ ] CI Snapshot tests step compiles past this point (verify post-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>