### PR TITLE
fix(ci): pin Xcode 26.5 on macos-26 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Select Xcode 26.5
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.5'
+          xcode-version: '26.5.0'
 
       - name: Show Swift version
         run: swift --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Select Xcode 26.5
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.5'
+
       - name: Show Swift version
         run: swift --version
 


### PR DESCRIPTION
Closes #141

## Summary
- pin CI macOS job to Xcode 26.5 using maxim-lobanov/setup-xcode@v1
- keep runner on macos-26 while aligning toolchain with local snapshot baselines

## Why
Snapshot tests were consistently red in CI due to Xcode 26.2 vs local 26.5 rendering drift.

## Validation
- workflow YAML updated and committed on dedicated fix branch
- CI now selects Xcode 26.5 before build/test steps
