### PR TITLE
fix: PlayerViewModel resubscribes to StreamHealth after XPC reconnect

### DIFF
--- a/App/Features/Player/PlayerViewModel.swift
+++ b/App/Features/Player/PlayerViewModel.swift
@@ -27,6 +27,8 @@ final class PlayerViewModel: ObservableObject {
 
     private let streamDescriptor: StreamDescriptorDTO
     private let engineClient: EngineClient
+    private var healthSubscription: AnyCancellable?
+    private var reconnectSubscription: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
     private var isClosed = false
 
@@ -52,7 +54,17 @@ final class PlayerViewModel: ObservableObject {
             scheduleResumeSeek(player: avPlayer, item: item)
         }
 
-        // Subscribe to health events.
+        // Re-bind to the active events stream whenever EngineClient reconnects.
+        reconnectSubscription = NotificationCenter.default.publisher(
+            for: EngineClient.eventsDidChangeNotification,
+            object: engineClient
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            Task { await self?.subscribeToHealth() }
+        }
+
+        // Subscribe to the current health stream.
         Task { await self.subscribeToHealth() }
     }
 
@@ -71,6 +83,10 @@ final class PlayerViewModel: ObservableObject {
     func close() {
         guard !isClosed else { return }
         isClosed = true
+        healthSubscription?.cancel()
+        reconnectSubscription?.cancel()
+        healthSubscription = nil
+        reconnectSubscription = nil
         cancellables.removeAll()
         player?.pause()
         player = nil
@@ -83,24 +99,18 @@ final class PlayerViewModel: ObservableObject {
     // MARK: - Private helpers
 
     /// Subscribe to StreamHealth events for this stream.
-    ///
-    /// Known limitation: if the engine XPC connection is invalidated and reconnected
-    /// while the player is open, the captured `EngineEventHandler` reference becomes
-    /// stale and health updates stop. The player does not auto-re-subscribe in v1.
-    /// Fix deferred: file follow-up task for the XPC reconnect handler to notify
-    /// active PlayerViewModels so they can re-subscribe.
     private func subscribeToHealth() async {
         guard let events = await engineClient.events else { return }
         guard !isClosed else { return }
         let targetID = streamDescriptor.streamID as String
 
-        events.streamHealthChangedSubject
+        healthSubscription?.cancel()
+        healthSubscription = events.streamHealthChangedSubject
             .filter { ($0.streamID as String) == targetID }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] dto in
                 self?.health = dto
             }
-            .store(in: &cancellables)
     }
 
     /// Once the asset duration is available, seeks to the byte-ratio–derived time.

--- a/App/Shared/EngineClient.swift
+++ b/App/Shared/EngineClient.swift
@@ -70,6 +70,10 @@ private final class ContinuationResumer<Value: Sendable>: @unchecked Sendable {
 ///   the reply-block API to Swift concurrency.
 public actor EngineClient {
 
+    /// Posted whenever this client's active `EngineEventHandler` changes.
+    nonisolated public static let eventsDidChangeNotification =
+        Notification.Name("EngineClient.eventsDidChange")
+
     // MARK: Private state
 
     private var connection: NSXPCConnection?
@@ -95,6 +99,7 @@ public actor EngineClient {
         let handler = EngineEventHandler()
         conn.exportedObject = handler
         eventHandler = handler
+        publishEventsDidChange()
 
         // Reject any peer not signed by the same Apple Development team as the app.
         // macOS 13+ API. Without this, a rogue local binary could impersonate the
@@ -126,6 +131,7 @@ public actor EngineClient {
         connection?.invalidate()
         connection = nil
         eventHandler = nil
+        publishEventsDidChange()
     }
 
     // MARK: - Async wrappers
@@ -362,6 +368,7 @@ public actor EngineClient {
     private func handleInvalidation() {
         connection = nil
         eventHandler = nil
+        publishEventsDidChange()
         NSLog("[EngineClient] XPC connection invalidated — reconnecting in 500 ms")
         Task {
             try? await Task.sleep(for: .milliseconds(500))
@@ -403,4 +410,16 @@ public actor EngineClient {
             }
         }
     }
+
+    private func publishEventsDidChange() {
+        NotificationCenter.default.post(name: Self.eventsDidChangeNotification, object: self)
+    }
+
+#if DEBUG
+    /// Test-only helper that simulates reconnect by replacing the current events handler.
+    internal func _replaceEventHandlerForTesting(_ handler: EngineEventHandler?) {
+        eventHandler = handler
+        publishEventsDidChange()
+    }
+#endif
 }

--- a/Tests/ButterBarTests/PlayerHUDSnapshotTests.swift
+++ b/Tests/ButterBarTests/PlayerHUDSnapshotTests.swift
@@ -128,6 +128,92 @@ final class PlayerHUDSnapshotTests: XCTestCase {
     }
 }
 
+@MainActor
+final class PlayerViewModelReconnectTests: XCTestCase {
+
+    func testPlayerViewModelResubscribesAfterEngineReconnect() async throws {
+        let engineClient = EngineClient()
+        let streamID = "stream-reconnect-1"
+        let descriptor = StreamDescriptorDTO(
+            streamID: streamID as NSString,
+            loopbackURL: "http://127.0.0.1:52100/stream/\(streamID)" as NSString,
+            contentType: "video/mp4",
+            contentLength: 10_000
+        )
+        let viewModel = PlayerViewModel(streamDescriptor: descriptor, engineClient: engineClient)
+
+        let firstHandler = EngineEventHandler()
+        await engineClient._replaceEventHandlerForTesting(firstHandler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        firstHandler.streamHealthChanged(
+            StreamHealthDTO(
+                streamID: streamID as NSString,
+                secondsBufferedAhead: 12,
+                downloadRateBytesPerSec: 500_000,
+                requiredBitrateBytesPerSec: nil,
+                peerCount: 4,
+                outstandingCriticalPieces: 0,
+                recentStallCount: 0,
+                tier: "healthy"
+            )
+        )
+        try await assertEventually("initial health should arrive") {
+            (viewModel.health?.tier as String?) == "healthy"
+        }
+
+        let secondHandler = EngineEventHandler()
+        await engineClient._replaceEventHandlerForTesting(secondHandler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        secondHandler.streamHealthChanged(
+            StreamHealthDTO(
+                streamID: streamID as NSString,
+                secondsBufferedAhead: 2,
+                downloadRateBytesPerSec: 90_000,
+                requiredBitrateBytesPerSec: nil,
+                peerCount: 1,
+                outstandingCriticalPieces: 3,
+                recentStallCount: 3,
+                tier: "starving"
+            )
+        )
+        try await assertEventually("health should resume from replacement handler") {
+            (viewModel.health?.tier as String?) == "starving"
+        }
+
+        firstHandler.streamHealthChanged(
+            StreamHealthDTO(
+                streamID: streamID as NSString,
+                secondsBufferedAhead: 6,
+                downloadRateBytesPerSec: 200_000,
+                requiredBitrateBytesPerSec: nil,
+                peerCount: 2,
+                outstandingCriticalPieces: 1,
+                recentStallCount: 1,
+                tier: "marginal"
+            )
+        )
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(viewModel.health?.tier as String?, "starving")
+    }
+
+    private func assertEventually(
+        _ message: String,
+        timeout: Duration = .seconds(1),
+        poll: Duration = .milliseconds(10),
+        condition: @escaping () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if condition() { return }
+            try await Task.sleep(for: poll)
+        }
+        XCTFail("Timed out: \(message)")
+    }
+}
+
 // MARK: - StreamHealthDTO test fixtures
 
 private extension StreamHealthDTO {


### PR DESCRIPTION
Closes #110

## Summary
- PlayerViewModel now observes EngineClient event-handler replacement notifications and re-subscribes to the active `streamHealthChangedSubject`
- removed the deferred reconnect limitation comment in `PlayerViewModel.subscribeToHealth()`
- added a reconnect unit test that simulates event-handler replacement and verifies health updates continue

## Spec refs
- `.claude/specs/03-xpc-contract.md` (connection model and reconnect behavior)

## Verification
- `xcodebuild build -scheme ButterBar -destination 'platform=macOS'`
- `xcodebuild test -scheme ButterBar -only-testing:ButterBarTests/PlayerHUDSnapshotTests -only-testing:ButterBarTests/PlayerViewModelReconnectTests -destination 'platform=macOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
