### PR TITLE
refactor: type StreamHealthDTO.tier via Swift enum at domain boundary

### DIFF
--- a/App/Features/Player/StreamHealthHUD.swift
+++ b/App/Features/Player/StreamHealthHUD.swift
@@ -39,7 +39,7 @@ struct StreamHealthHUD: View {
             .fill(tierColour)
             .frame(width: 4)
             .clipShape(Capsule())
-            .animation(.easeInOut(duration: 0.4), value: health.tier as String)
+            .animation(.easeInOut(duration: 0.4), value: health.tierValue)
     }
 
     // MARK: - Stats row
@@ -58,7 +58,7 @@ struct StreamHealthHUD: View {
         Text(tierDisplayName)
             .brandBodyEmphasis()
             .foregroundStyle(tierColour)
-            .animation(.easeInOut(duration: 0.4), value: health.tier as String)
+            .animation(.easeInOut(duration: 0.4), value: health.tierValue)
     }
 
     /// "12 s ready" — buffer-ahead value animates continuously across 800 ms.
@@ -113,21 +113,19 @@ struct StreamHealthHUD: View {
     // MARK: - Formatters
 
     private var tierColour: Color {
-        switch health.tier as String {
-        case "healthy":  return BrandColors.tierHealthy
-        case "marginal": return BrandColors.tierMarginal
-        case "starving": return BrandColors.tierStarving
-        default:         return BrandColors.tierStarving
+        switch health.tierValue {
+        case .healthy:  return BrandColors.tierHealthy
+        case .marginal: return BrandColors.tierMarginal
+        case .starving: return BrandColors.tierStarving
         }
     }
 
     /// British English tier names per 06-brand.md § Voice.
     private var tierDisplayName: String {
-        switch health.tier as String {
-        case "healthy":  return "Healthy"
-        case "marginal": return "Marginal"
-        case "starving": return "Starving"
-        default:         return "Unknown"
+        switch health.tierValue {
+        case .healthy:  return "Healthy"
+        case .marginal: return "Marginal"
+        case .starving: return "Starving"
         }
     }
 

--- a/Packages/EngineInterface/Sources/EngineInterface/StreamHealthDTO.swift
+++ b/Packages/EngineInterface/Sources/EngineInterface/StreamHealthDTO.swift
@@ -37,6 +37,29 @@ public final class StreamHealthDTO: NSObject, NSSecureCoding {
         self.tier = tier
     }
 
+    /// Convenience constructor for typed tier call sites.
+    public convenience init(
+        streamID: NSString,
+        secondsBufferedAhead: Double,
+        downloadRateBytesPerSec: Int64,
+        requiredBitrateBytesPerSec: NSNumber?,
+        peerCount: Int32,
+        outstandingCriticalPieces: Int32,
+        recentStallCount: Int32,
+        tier: StreamHealthTier
+    ) {
+        self.init(
+            streamID: streamID,
+            secondsBufferedAhead: secondsBufferedAhead,
+            downloadRateBytesPerSec: downloadRateBytesPerSec,
+            requiredBitrateBytesPerSec: requiredBitrateBytesPerSec,
+            peerCount: peerCount,
+            outstandingCriticalPieces: outstandingCriticalPieces,
+            recentStallCount: recentStallCount,
+            tier: tier.rawValue as NSString
+        )
+    }
+
     public func encode(with coder: NSCoder) {
         coder.encode(schemaVersion, forKey: "schemaVersion")
         coder.encode(streamID, forKey: "streamID")
@@ -61,5 +84,10 @@ public final class StreamHealthDTO: NSObject, NSSecureCoding {
         guard let tier = coder.decodeObject(of: NSString.self, forKey: "tier") else { return nil }
         self.streamID = streamID
         self.tier = tier
+    }
+
+    /// Typed projection of `tier` for domain/UI use. Unknown strings map to `.starving`.
+    public var tierValue: StreamHealthTier {
+        StreamHealthTier(rawValue: tier as String) ?? .starving
     }
 }

--- a/Packages/EngineInterface/Sources/EngineInterface/StreamHealthTier.swift
+++ b/Packages/EngineInterface/Sources/EngineInterface/StreamHealthTier.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Typed tier projection for `StreamHealthDTO`.
+///
+/// The XPC wire format remains `NSString` (`StreamHealthDTO.tier`) to preserve
+/// NSSecureCoding compatibility; this enum is a domain-layer convenience.
+public enum StreamHealthTier: String, Codable, Sendable, CaseIterable {
+    case healthy
+    case marginal
+    case starving
+}

--- a/Packages/EngineInterface/Tests/EngineInterfaceTests/EngineInterfaceTests.swift
+++ b/Packages/EngineInterface/Tests/EngineInterfaceTests/EngineInterfaceTests.swift
@@ -284,6 +284,35 @@ final class StreamHealthDTOTests: XCTestCase {
         XCTAssertEqual(decoded.requiredBitrateBytesPerSec?.int64Value, 1_800_000)
         XCTAssertEqual(decoded.tier, "marginal")
     }
+
+    func testTierValue_typedProjectionMatchesRawTier() {
+        let dto = StreamHealthDTO(
+            streamID: "sh-typed",
+            secondsBufferedAhead: 1,
+            downloadRateBytesPerSec: 1,
+            requiredBitrateBytesPerSec: nil,
+            peerCount: 0,
+            outstandingCriticalPieces: 0,
+            recentStallCount: 0,
+            tier: .healthy
+        )
+        XCTAssertEqual(dto.tierValue, .healthy)
+        XCTAssertEqual(dto.tier as String, "healthy")
+    }
+
+    func testTierValue_unknownTierFallsBackToStarving() {
+        let dto = StreamHealthDTO(
+            streamID: "sh-unknown",
+            secondsBufferedAhead: 1,
+            downloadRateBytesPerSec: 1,
+            requiredBitrateBytesPerSec: nil,
+            peerCount: 0,
+            outstandingCriticalPieces: 0,
+            recentStallCount: 0,
+            tier: "not-a-tier"
+        )
+        XCTAssertEqual(dto.tierValue, .starving)
+    }
 }
 
 // MARK: - DiskPressureDTO

--- a/Packages/XPCMapping/Sources/XPCMapping/Mapping.swift
+++ b/Packages/XPCMapping/Sources/XPCMapping/Mapping.swift
@@ -152,6 +152,7 @@ extension FileAvailability {
 extension StreamHealthDTO {
     /// Construct a DTO from a domain health snapshot, attaching the stream context.
     public convenience init(streamID: String, from domain: StreamHealth) {
+        let tier = StreamHealthTier(rawValue: domain.tier.rawValue) ?? .starving
         self.init(
             streamID: streamID as NSString,
             secondsBufferedAhead: domain.secondsBufferedAhead,
@@ -160,7 +161,7 @@ extension StreamHealthDTO {
             peerCount: Int32(clamping: domain.peerCount),
             outstandingCriticalPieces: Int32(clamping: domain.outstandingCriticalPieces),
             recentStallCount: Int32(clamping: domain.recentStallCount),
-            tier: domain.tier.rawValue as NSString
+            tier: tier
         )
     }
 }
@@ -175,7 +176,7 @@ extension StreamHealth {
             peerCount: Int(dto.peerCount),
             outstandingCriticalPieces: Int(dto.outstandingCriticalPieces),
             recentStallCount: Int(dto.recentStallCount),
-            tier: StreamHealth.Tier(rawValue: dto.tier as String) ?? .starving
+            tier: StreamHealth.Tier(rawValue: dto.tierValue.rawValue) ?? .starving
         )
     }
 }

--- a/Packages/XPCMapping/Tests/XPCMappingTests/MappingTests.swift
+++ b/Packages/XPCMapping/Tests/XPCMappingTests/MappingTests.swift
@@ -266,6 +266,21 @@ final class MappingTests: XCTestCase {
         }
     }
 
+    func test_streamHealth_unknownTierFallsBackToStarving() {
+        let dto = StreamHealthDTO(
+            streamID: "s",
+            secondsBufferedAhead: 0,
+            downloadRateBytesPerSec: 0,
+            requiredBitrateBytesPerSec: nil,
+            peerCount: 0,
+            outstandingCriticalPieces: 0,
+            recentStallCount: 0,
+            tier: "unexpected"
+        )
+        let reconstructed = StreamHealth(from: dto)
+        XCTAssertEqual(reconstructed.tier, .starving)
+    }
+
     func test_streamHealth_roundTrip_zeroCounts() {
         let domain = StreamHealth(
             secondsBufferedAhead: 0.0,


### PR DESCRIPTION
Closes #117

## Summary
- added typed `StreamHealthTier` enum in `EngineInterface`
- kept XPC wire contract unchanged (`StreamHealthDTO.tier` stays `NSString`) and added typed projection via `StreamHealthDTO.tierValue`
- switched `StreamHealthHUD` tier switches/animations to enum-based logic
- updated XPC mapping to convert between domain tiers and the typed projection with an explicit unknown-tier fallback to `.starving`
- added coverage for typed projection and unknown-tier fallback in both `EngineInterface` and `XPCMapping` tests

## Spec refs
- `.claude/specs/02-stream-health.md`
- `.claude/specs/03-xpc-contract.md`

## Verification
- `swift test --package-path Packages/EngineInterface`
- `swift test --package-path Packages/XPCMapping`
- `xcodebuild build -scheme ButterBar -destination 'platform=macOS'`
- `xcodebuild test -scheme ButterBar -only-testing:ButterBarTests/PlayerHUDSnapshotTests -destination 'platform=macOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
