### PR TITLE
fix: statusSnapshot includes torrent name

### DIFF
--- a/EngineService/Bridge/AlertDispatcher.swift
+++ b/EngineService/Bridge/AlertDispatcher.swift
@@ -76,11 +76,10 @@ final class AlertDispatcher {
         }
 
         let progress = (snapshot["progress"] as? NSNumber)?.floatValue ?? 0
+        let name = (snapshot["name"] as? NSString) ?? (torrentID as NSString)
         let dto = TorrentSummaryDTO(
             torrentID: torrentID as NSString,
-            // statusSnapshot does not include a name; use a placeholder.
-            // The real name will be available once the torrent is tracked in the store layer.
-            name: torrentID as NSString,
+            name: name,
             totalBytes: (snapshot["totalBytes"] as? NSNumber)?.int64Value ?? 0,
             progressQ16: Int32(min(progress * 65536, 65536)),
             state: (snapshot["state"] as? NSString) ?? ("unknown" as NSString),

--- a/EngineService/Bridge/TorrentBridge.h
+++ b/EngineService/Bridge/TorrentBridge.h
@@ -127,7 +127,7 @@ overwriteExisting:(BOOL)overwriteExisting
 // MARK: - Status
 
 /// Returns a snapshot of the torrent's current status.
-/// Dict keys: @"state" (NSString), @"progress" (NSNumber float),
+/// Dict keys: @"name" (NSString), @"state" (NSString), @"progress" (NSNumber float),
 ///            @"downloadRate" (NSNumber int64), @"uploadRate" (NSNumber int64),
 ///            @"peerCount" (NSNumber int), @"totalBytes" (NSNumber int64).
 - (nullable NSDictionary *)statusSnapshot:(NSString *)torrentID error:(NSError **)error;

--- a/EngineService/Bridge/TorrentBridge.mm
+++ b/EngineService/Bridge/TorrentBridge.mm
@@ -445,8 +445,17 @@ overwriteExisting:(BOOL)overwriteExisting
 
         lt::torrent_status st = h.status();
         NSString *stateStr = [TorrentBridge _stateStringFrom:st.state];
+        NSString *nameStr = torrentID;
+
+        if (auto ti = h.torrent_file()) {
+            const std::string name = ti->name();
+            if (!name.empty()) {
+                nameStr = [NSString stringWithUTF8String:name.c_str()];
+            }
+        }
 
         result = @{
+            @"name":         nameStr,
             @"state":        stateStr,
             @"progress":     @((float)st.progress),
             @"downloadRate": @((int64_t)st.download_rate),

--- a/EngineService/XPC/RealEngineBackend.swift
+++ b/EngineService/XPC/RealEngineBackend.swift
@@ -484,9 +484,10 @@ final class RealEngineBackend: EngineXPCBackend {
         }
 
         let progress = (snapshot["progress"] as? NSNumber)?.floatValue ?? 0
+        let name = (snapshot["name"] as? NSString) ?? (torrentID as NSString)
         return TorrentSummaryDTO(
             torrentID: torrentID as NSString,
-            name: torrentID as NSString,      // real name comes from metadata alert
+            name: name,
             totalBytes: (snapshot["totalBytes"] as? NSNumber)?.int64Value ?? 0,
             progressQ16: Int32(min(progress * 65536, 65536)),
             state: (snapshot["state"] as? NSString) ?? ("unknown" as NSString),


### PR DESCRIPTION
Closes #92

## Summary
- `TorrentBridge.statusSnapshot` now includes a `name` field sourced from `torrent_info::name()` once metadata is available (fallback: `torrentID`)
- `AlertDispatcher` now uses `snapshot["name"]` when emitting `TorrentSummaryDTO`
- `RealEngineBackend.buildSummaryDTO` now also uses `snapshot["name"]` so list/open stream paths return the same name source
- updated `TorrentBridge.h` statusSnapshot contract docs to include the new `name` key

## Decision
Store-layer naming is not available yet (`EngineStore` currently has playback history, pinned files, settings only), so this implementation takes option 1 (bridge snapshot) while preserving a fallback.

## Spec refs
- `.claude/specs/01-architecture.md`
- `.claude/specs/05-cache-policy.md`

## Verification
- `xcodebuild build -scheme EngineService -destination 'platform=macOS'`
- `swift test --package-path Packages/EngineStore`
