### PR TITLE
fix: harden EngineClient reconnect notification delivery

### DIFF
--- a/App/Shared/EngineClient.swift
+++ b/App/Shared/EngineClient.swift
@@ -412,7 +412,10 @@ public actor EngineClient {
     }
 
     private func publishEventsDidChange() {
-        NotificationCenter.default.post(name: Self.eventsDidChangeNotification, object: self)
+        let notification = Self.eventsDidChangeNotification
+        Task { @MainActor [notification, object = self] in
+            NotificationCenter.default.post(name: notification, object: object)
+        }
     }
 
 #if DEBUG

--- a/Tests/ButterBarTests/PlayerHUDSnapshotTests.swift
+++ b/Tests/ButterBarTests/PlayerHUDSnapshotTests.swift
@@ -131,6 +131,23 @@ final class PlayerHUDSnapshotTests: XCTestCase {
 @MainActor
 final class PlayerViewModelReconnectTests: XCTestCase {
 
+    func testEventsDidChangeNotificationIsDeliveredOnMainThread() async {
+        let engineClient = EngineClient()
+        let notificationExpectation = expectation(description: "eventsDidChange notification")
+        let observer = NotificationCenter.default.addObserver(
+            forName: EngineClient.eventsDidChangeNotification,
+            object: engineClient,
+            queue: nil
+        ) { _ in
+            XCTAssertTrue(Thread.isMainThread, "eventsDidChange should be delivered on main thread")
+            notificationExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        await engineClient._replaceEventHandlerForTesting(EngineEventHandler())
+        await fulfillment(of: [notificationExpectation], timeout: 1.0)
+    }
+
     func testPlayerViewModelResubscribesAfterEngineReconnect() async throws {
         let engineClient = EngineClient()
         let streamID = "stream-reconnect-1"


### PR DESCRIPTION
## Summary
- post `EngineClient.eventsDidChangeNotification` from `@MainActor`
- add a regression test asserting the notification is delivered on main thread
- keep reconnect re-subscribe behavior unchanged

## Why
A crash report showed `PlayerViewModel` reconnect subscription being invoked from a non-main queue, triggering a Swift concurrency isolation trap.

## Validation
- `xcodebuild test -quiet -scheme ButterBar -only-testing:ButterBarTests/PlayerViewModelReconnectTests -destination 'platform=macOS' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
