### PR TITLE
docs: phase 1 watch-state design (epic #5 foundation)

### DIFF
--- a/.claude/specs/00-addendum.md
+++ b/.claude/specs/00-addendum.md
@@ -403,11 +403,43 @@ That property is verified by the correctness tests (fixture replay, byte-for-byt
 - `docs/benchmarks/README.md` — § Deferred: regression gate threshold rewritten to "Regression threshold" and pointed at A25.
 - `TASKS.md` — `T-PERF-SEEK-BENCH` follow-up note marks #107 resolved.
 
+## A26 — `playback_history.completed_at` for watch state foundation (Epic #5 Phase 1)
+
+**Context:** Epic #5 Phase 1 foundation (#34) defines the app-side `WatchStatus` enum, with `.watched(completedAt: Date)` and `.reWatching(_, _, previouslyCompletedAt: Date)` cases. Spec 05 rev 4 stores `completed: Bool` on `playback_history` but no completion timestamp. The library UI needs that timestamp to show honest "Watched X days ago" copy and to preserve the original completion date across re-watches. Approximating from `last_played_at` was rejected during the design pass: re-watching mutates `last_played_at`, which would silently overwrite the original completion time.
+
+**Decision:** Add `completed_at INTEGER NULL` (unix milliseconds) to the `playback_history` table. Write rules:
+
+- Engine sets `completed_at = now()` whenever `completed` transitions 0 → 1 (either by the spec 05 § Update rules byte criterion `resume_byte_offset >= 0.95 * file_size`, or by manual mark-watched via the new XPC method introduced in #34).
+- Subsequent re-completions during a re-watch (the byte criterion re-firing while `completed` is already 1) **also** update `completed_at = now()`. Most-recent-completion-wins; the original completion date is unrecoverable in v1, by design.
+- Manual mark-unwatched (XPC) sets `completed = 0`, `completed_at = NULL`, `resume_byte_offset = 0`. `last_played_at` is preserved so library ordering does not jump.
+- The next stream open after completion still resets `resume_byte_offset = 0` per spec 05 unchanged; it does **not** clear `completed` or `completed_at`.
+
+**Migration:** new GRDB migration `v2_add_completed_at` is additive and backward-compatible. Rows created under V1 carry `completed_at = NULL`; the engine fills the column at the next completion. Loss of historical completion timestamps for already-completed rows is acceptable for v1.
+
+**XPC contract additions** (also part of #34):
+- New DTO `PlaybackHistoryDTO` (`schemaVersion = 1`, NSSecureCoding) carrying every column of `playback_history` including the new `completedAt` (nullable).
+- New method `EngineXPC.listPlaybackHistory(reply: ([PlaybackHistoryDTO]) -> Void)` — the app's first read path into the table. Returns `[]` when empty.
+- New event `EngineEvents.playbackHistoryChanged(_ dto: PlaybackHistoryDTO)` — emitted exactly once per write (15 s tick, stream close, manual toggle). Coalescing is the engine's responsibility.
+
+Both follow the response/event versioning rule from A1.
+
+**Affected files:**
+- `05-cache-policy.md` — rev 5: § Schema gains the new column; § Update rules gain the `completed_at` write semantics; § Resume offset persistence gains a manual-toggle reference.
+- `Packages/EngineStore/Sources/EngineStore/V1Migration.swift` — companion `V2Migration` added; `EngineDatabase` registers both.
+- `Packages/EngineStore/Sources/EngineStore/PlaybackHistoryRecord.swift` — `completedAt: Int64?` field added.
+- `Packages/EngineInterface/Sources/EngineInterface/PlaybackHistoryDTO.swift` — new file.
+- `Packages/EngineInterface/Sources/EngineInterface/EngineXPCProtocol.swift` — `listPlaybackHistory` added.
+- `Packages/EngineInterface/Sources/EngineInterface/EngineEventsProtocol.swift` — `playbackHistoryChanged` added.
+- `EngineService/Cache/CacheManager.swift` — write rules above implemented; event emitted after every write.
+- `EngineService/XPC/EngineXPCServer.swift` (and `RealEngineBackend`) — `listPlaybackHistory` wired.
+- `Packages/LibraryDomain/` — new local SPM package containing `WatchStatus`, `WatchEvent`, `WatchStateMachine`, and the derivation helpers.
+- `docs/design/watch-state-foundation.md` — full design record (transition matrix, write rules, test shape).
+
 ## Summary of file changes in this revision
 
 (extends earlier summaries)
 
-- `00-addendum.md` — A16–A19 appended in earlier revision; A20–A22 appended from Phase 1 review; A23 appended from 2026-04-16 API surface investigation; A24 appended same-day after probe run #3 disproved A23's hot path; A25 appended 2026-04-16 to resolve #107 (planner seek SLA + 50% regression threshold, advisory-only, E2E SLA deferred to v1.5+).
+- `00-addendum.md` — A16–A19 appended in earlier revision; A20–A22 appended from Phase 1 review; A23 appended from 2026-04-16 API surface investigation; A24 appended same-day after probe run #3 disproved A23's hot path; A25 appended 2026-04-16 to resolve #107 (planner seek SLA + 50% regression threshold, advisory-only, E2E SLA deferred to v1.5+); A26 appended 2026-04-16 to add `playback_history.completed_at` plus the `listPlaybackHistory` / `playbackHistoryChanged` XPC surface for Epic #5 Phase 1 foundation (#34).
 - `06-brand.md` — rev 3: § Asset specifications and § Tahoe icon workflow rewritten around the Liquid Glass prep package. Layer model corrected (background + up to 4 foreground groups). `.icon` placement corrected to `App/AppIcon.icon` (sibling of Assets.xcassets, not nested). Step-by-step Icon Composer workflow added. (A19.) Rev 2 introduced Tahoe targeting (A18); rev 1 was the initial brand spec.
 - `07-product-surface.md` — authoritative product surface spec for catalogue, sync, providers, etc. (A17.)
 - `08-issue-workflow.md` — GitHub issue/branch/PR conventions. (A17.)

--- a/.claude/specs/05-cache-policy.md
+++ b/.claude/specs/05-cache-policy.md
@@ -1,6 +1,6 @@
 # 05 — Cache Policy
 
-> **Revision 4** — § Piece eviction mechanism rewritten again after probe run #3 (2026-04-16) empirically disproved the addPiece/hash-fail hot path in libtorrent 2.0.12. The new mechanism is `F_PUNCHHOLE` + `force_recheck()` (addendum A24). Rev 3 proposed add_piece+punch (A23, now retracted). Rev 2 weakened resume offset to byte-last-served (A6) and added `settings` + `pinned_files` schemas (A7).
+> **Revision 5** — § Schema gains `playback_history.completed_at`; § Update rules gain the `completed_at` and manual-toggle write semantics (addendum A26, 2026-04-16, for Epic #5 Phase 1 foundation #34). Rev 4 rewrote § Piece eviction mechanism around `F_PUNCHHOLE` + `force_recheck()` after probe run #3 disproved the addPiece/hash-fail hot path (A24). Rev 3 proposed add_piece+punch (A23, now retracted). Rev 2 weakened resume offset to byte-last-served (A6) and added `settings` + `pinned_files` schemas (A7).
 
 Cache eviction is piece-granular, not file-granular. The unit of value is "pieces the user is likely to need next," not "whole torrents."
 
@@ -108,6 +108,7 @@ CREATE TABLE playback_history (
     last_played_at INTEGER NOT NULL,            -- unix ms
     total_watched_seconds REAL NOT NULL DEFAULT 0,  -- populated from CMTime observations
     completed INTEGER NOT NULL DEFAULT 0,
+    completed_at INTEGER,                       -- unix ms; NULL until first completion (A26)
     PRIMARY KEY (torrent_id, file_index)
 );
 
@@ -129,7 +130,11 @@ CREATE TABLE settings (
 
 - Engine updates `resume_byte_offset` on stream close and on a 15-second interval during active playback.
 - `total_watched_seconds` is incremented from AVPlayer's time observer callbacks on the app side and forwarded to the engine via a dedicated XPC method (deferred to v1.1; the column exists but stays at 0 in v1).
-- `completed = 1` when `resume_byte_offset >= 0.95 * file_size`. On the next stream open, reset `resume_byte_offset = 0`.
+- `completed = 1` when `resume_byte_offset >= 0.95 * file_size`. On the next stream open, reset `resume_byte_offset = 0` (do **not** clear `completed` or `completed_at`; that re-watch is part of the row's history).
+- `completed_at` (A26): set to `now()` on every `completed` 0 → 1 transition, including the initial completion and any subsequent re-completion during a re-watch. Never auto-cleared except by manual mark-unwatched. Most-recent-completion-wins is the v1 rule; preserving the original first-completion date would require a per-watch event log (v2+).
+- **Manual mark-watched** (XPC, introduced with #34): set `completed = 1`, `completed_at = now()`, `resume_byte_offset = 0`. Inserts the row if absent (`last_played_at = now()`).
+- **Manual mark-unwatched** (XPC, introduced with #34): set `completed = 0`, `completed_at = NULL`, `resume_byte_offset = 0`. `last_played_at` is preserved so library ordering does not jump.
+- After **every** write the engine emits `EngineEvents.playbackHistoryChanged(_:)` exactly once (A26). The 15-second tick is the natural coalescing point during active playback.
 
 ### What this means for the UI
 

--- a/.claude/tasks/TASKS.md
+++ b/.claude/tasks/TASKS.md
@@ -376,6 +376,38 @@ Benchmark: measure seek-to-first-frame time across the four trace fixtures. Reco
 
 ---
 
+## Phase 8 — Product-surface engine seams
+
+Engine seams discovered during product-surface execution (per `docs/v1-roadmap.md § Missing engine seams`). Each seam is small, additive, and unblocks one or more product-surface issues.
+
+### T-STORE-FAVOURITES `[sonnet]` · TODO
+Add a GRDB additive migration for the `favourites` table per spec 07 § 4 (Watch state and local library). Schema:
+
+```sql
+CREATE TABLE favourites (
+    torrent_id TEXT NOT NULL,
+    file_index INTEGER NOT NULL,
+    favourited_at INTEGER NOT NULL,    -- unix ms
+    PRIMARY KEY (torrent_id, file_index)
+);
+```
+
+Implement `FavouriteRecord: Codable, FetchableRecord, PersistableRecord` mirroring `PinnedFileRecord`. Migration identifier: `v2_add_favourites` (named, not sequential — independent of `v2_add_completed_at` introduced by #34; migrations apply in registration order). Both can land in either order; neither blocks the other.
+
+**Spec:** `07-product-surface.md § 4` (favourites required feature); `08-issue-workflow.md` (engine task workflow).
+**Acceptance:**
+- Migration runs cleanly on a fresh database (V1 → V1+favourites).
+- Migration is idempotent (re-running is a no-op).
+- Migration runs cleanly on a database that already has `v2_add_completed_at` applied.
+- `FavouriteRecord` round-trip insert/fetch test passes.
+- Schema version recorded in GRDB's migration table under the named identifier.
+- No XPC / DTO work in this task — that's the `#36` GitHub issue's scope.
+
+**Blocks:** GitHub issue #36 (favourites feature).
+**Found during:** Epic #5 Phase 1 Opus design pass (2026-04-16). See `docs/design/watch-state-foundation.md`.
+
+---
+
 ## Escalation protocol
 
 Any task marked `BLOCKED:` halts work on that task. The blocking reason goes in the task description. Opus triages blocked tasks at the next review gate or on explicit request.

--- a/docs/design/watch-state-foundation.md
+++ b/docs/design/watch-state-foundation.md
@@ -1,0 +1,265 @@
+# Watch state foundation — design (Phase 1)
+
+> **Scope:** the foundation ticket for Epic #5 (#34). Defines `WatchStatus`, the
+> deterministic transitions that drive it, the engine schema and XPC surface
+> that feed it, and the test shape every Phase 1 ticket consumes.
+>
+> **Status:** Opus design pass, 2026-04-16. Approved before implementation.
+
+## Why a design doc
+
+Phase 1's foundation ticket sits between three frozen surfaces:
+
+1. **Engine schema** (`05-cache-policy.md` § Schema, `EngineStore`).
+2. **XPC contract** (`03-xpc-contract.md`, `EngineInterface`).
+3. **Brand-compliant library UI** (`06-brand.md`, `App/Features/Library`).
+
+The watch state model has to be coherent across all three without bloating any
+of them. This doc records the choices so dependent tickets (#35, #36, #37) can
+implement against a stable target.
+
+## Decisions
+
+### D1 — `WatchStatus` carries a real `completedAt: Date`
+
+The hinted enum shape on #34 included `.watched(completedAt:)`. To make that
+honest we add a new column on `playback_history`:
+
+- **Schema**: `completed_at INTEGER NULL` (unix ms), additive V2 migration
+  named `v2_add_completed_at`. Existing rows get `NULL`; the engine fills it
+  on the next completion.
+- **Spec**: spec 05 → rev 5; addendum **A26** records the rule.
+- **Rejected alternative**: derive timestamp from `last_played_at`. Wrong
+  semantics — re-watch updates `last_played_at` and would silently overwrite
+  the original completion time. Library copy "Watched 3 days ago" would
+  drift after every re-open.
+
+### D2 — Progress is byte-accurate, not time-accurate
+
+`WatchStatus` carries `progressBytes: Int64` and `totalBytes: Int64`, never
+seconds. This matches spec 05 rev 4 (A6): the v1 cache spec deliberately
+weakened resume to "last byte served." Container-aware byte→time mapping is
+v1.5+ work. The library progress bar uses `progressBytes / totalBytes`, per
+spec 05 § "What this means for the UI".
+
+The hint in #34 (`progressSeconds:`) was the issue body's original placeholder
+text and is superseded here.
+
+### D3 — `WatchStatus` is app-side; engine writes the source rows
+
+The engine remains the sole writer of `playback_history` (single-writer
+ownership per spec 01). It does not know about "re-watching" or "watched";
+those are app-derived from a row plus `totalBytes`.
+
+The app cannot derive watch status today: there is no XPC method to read
+`playback_history` rows, only the per-stream `StreamDescriptorDTO.resumeByteOffset`.
+We therefore extend the XPC contract:
+
+- **DTO**: `PlaybackHistoryDTO` (`schemaVersion = 1`, NSSecureCoding).
+- **Method**: `EngineXPC.listPlaybackHistory(reply: ([PlaybackHistoryDTO]) -> Void)`.
+- **Event**: `EngineEvents.playbackHistoryChanged(_ dto: PlaybackHistoryDTO)`,
+  emitted on every write (15 s tick, stream close, manual toggle).
+- **Versioning**: response/event DTOs are versioned per A1; new methods are
+  backward-compatible per the same rule.
+
+### D4 — Re-watch is derived, not persisted as a third state
+
+We keep `playback_history.completed: Bool`. "Re-watching" is the row state
+`(completed = 1, resumeByteOffset > 0)`. This holds because:
+
+- Spec 05 already resets `resume_byte_offset = 0` on the next stream open
+  after completion.
+- The engine never clears `completed` automatically; only manual mark-unwatched
+  flips it back to 0.
+- Therefore any positive offset on a row with `completed = 1` is, by
+  construction, an in-flight re-watch.
+
+A subsequent re-completion during a re-watch updates `completed_at = now()`
+(most recent completion wins). This trades the "original first watched" date
+for predictable copy in the library — the row always answers "when did you
+last finish this?" rather than "when did you first finish this?". The
+distinction is unrecoverable in v1 without a watch-event log, which is out
+of scope.
+
+### D5 — `WatchStateMachine` is a pure function, no clocks
+
+Mirrors the planner discipline (addendum A3). All transitions live in
+`WatchStateMachine.apply(_:to:now:)`, take their `now: Date` as an injected
+parameter, and have no I/O, no `DispatchQueue`, no real clocks. The
+state-machine tests are therefore deterministic.
+
+The engine's persistence path is *not* this state machine — it writes raw
+`(completed, completed_at, resume_byte_offset)` per the rules in §
+"Engine write rules" below. The state machine is the app-side mirror used
+for command handling (mark-watched, mark-unwatched, observed events).
+
+## Type sketch
+
+```swift
+// Packages/LibraryDomain (new package, depends on EngineInterface)
+
+public enum WatchStatus: Equatable, Sendable {
+    case unwatched
+    case inProgress(progressBytes: Int64, totalBytes: Int64)
+    case watched(completedAt: Date)
+    case reWatching(progressBytes: Int64,
+                    totalBytes: Int64,
+                    previouslyCompletedAt: Date)
+}
+
+public extension WatchStatus {
+    /// Project a row from the engine into a status for the UI.
+    /// `nil` row → `.unwatched` (file has no playback history).
+    static func from(history: PlaybackHistoryDTO?,
+                     totalBytes: Int64) -> WatchStatus
+}
+
+public enum WatchEvent: Equatable, Sendable {
+    case streamOpened(totalBytes: Int64)
+    case progress(bytes: Int64, totalBytes: Int64)
+    case streamClosed(finalBytes: Int64, totalBytes: Int64)
+    case manuallyMarkedWatched(at: Date)
+    case manuallyMarkedUnwatched
+}
+
+public enum WatchStateMachine {
+    public static func apply(_ event: WatchEvent,
+                             to status: WatchStatus,
+                             now: Date) -> WatchStatus
+}
+```
+
+## Derivation matrix (DTO → `WatchStatus`)
+
+`history` is a `PlaybackHistoryDTO?`; `total = totalBytes`.
+
+| `completed` | `completed_at` | `resume_byte_offset` | result                                                      |
+| ----------- | -------------- | -------------------- | ----------------------------------------------------------- |
+| (row absent)| —              | —                    | `.unwatched`                                                |
+| `false`     | `NULL`         | `0`                  | `.unwatched`                                                |
+| `false`     | `NULL`         | `n > 0`              | `.inProgress(n, total)`                                     |
+| `true`      | `T`            | `0`                  | `.watched(T)`                                               |
+| `true`      | `T`            | `n > 0`              | `.reWatching(n, total, T)`                                  |
+| `true`      | `NULL`         | any                  | **invariant violation** — log + treat as `.watched(now)`    |
+| `false`     | `T ≠ NULL`     | any                  | **invariant violation** — log + treat as `.inProgress`/`.unwatched` per offset |
+
+Engine writes guarantee the invariants; the violation rows exist only as
+defensive UI fallbacks.
+
+## Transition matrix (`WatchStateMachine.apply`)
+
+Rows are current `WatchStatus`; columns are `WatchEvent`. Cells give the
+resulting status.
+
+`s.opened(T)` = `streamOpened(totalBytes: T)`
+`prog(b,T)` = `progress(bytes: b, totalBytes: T)`
+`s.closed(b,T)` = `streamClosed(finalBytes: b, totalBytes: T)`
+`mark.W` = `manuallyMarkedWatched(at: now)`
+`mark.U` = `manuallyMarkedUnwatched`
+**threshold** = `b ≥ Int64(0.95 * Double(T))` (matches spec 05 § Update rules)
+
+| from \ event | `s.opened(T)`               | `prog(b,T)`                                | `s.closed(b,T)`                                                         | `mark.W`             | `mark.U`     |
+| ------------ | --------------------------- | ------------------------------------------ | ----------------------------------------------------------------------- | -------------------- | ------------ |
+| `.unwatched` | `.inProgress(0,T)`          | `.inProgress(b,T)`                         | `.unwatched` (b=0) <br> `.watched(now)` (threshold) <br> `.inProgress(b,T)` (otherwise) | `.watched(now)`      | `.unwatched` |
+| `.inProgress(p,T)` | `.inProgress(p,T)` (idempotent) | `.inProgress(max(p,b), T)`         | `.watched(now)` (threshold) <br> `.inProgress(max(p,b),T)` (otherwise)   | `.watched(now)`      | `.unwatched` |
+| `.watched(W)` | `.reWatching(0,T,W)`        | invariant — must `.opened` first; log + treat as `.reWatching(b,T,W)` | `.watched(W)` (idempotent — closed without progress)                  | `.watched(W)` (no-op; keeps original W) | `.unwatched` |
+| `.reWatching(p,T,W)` | `.reWatching(p,T,W)` (idempotent) | `.reWatching(max(p,b),T,W)`     | `.watched(now)` (threshold; **W replaced by `now`**) <br> `.reWatching(max(p,b),T,W)` (otherwise) | `.watched(now)` (W replaced) | `.unwatched` |
+
+Notes:
+
+- `manuallyMarkedWatched` on `.watched(W)` is a no-op: keeping the original
+  date matches user intent ("I'm just confirming, not re-stamping").
+- `manuallyMarkedWatched` on `.reWatching(_, _, W)` **does** replace W with
+  now, because the user is asserting "treat this as freshly watched right
+  now" rather than just confirming the prior watch.
+- Crossing the threshold during a re-watch replaces W. This is the
+  most-recent-completion-wins rule from D4.
+
+## Engine write rules (mirror of the state machine)
+
+Lives in `CacheManager` and is invoked from the existing 15 s tick / close
+path plus a new manual-toggle XPC method.
+
+| Trigger                                  | Resulting row state                                                                                       |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Stream open on never-played file         | Insert `(resume=0, last_played=now, completed=0, completed_at=NULL)` (existing behaviour)                 |
+| 15 s tick during play                    | Update `resume_byte_offset = b, last_played_at = now`. If `b ≥ 0.95*size` AND `completed=0`: also set `completed=1, completed_at=now` |
+| Tick during play after re-completion     | If `completed=1` AND `b ≥ 0.95*size` AND `b > stored resume`: update `completed_at=now` (most recent wins) |
+| Stream close                             | Same rule as the 15 s tick, evaluated on the final byte                                                   |
+| Stream open after completion             | Reset `resume_byte_offset = 0`; **do not** clear `completed` or `completed_at` (re-watch starts here)     |
+| Manual mark-watched (XPC)                | Set `completed=1, completed_at=now, resume_byte_offset=0` (creates row if absent; `last_played_at=now`)   |
+| Manual mark-unwatched (XPC)              | Set `completed=0, completed_at=NULL, resume_byte_offset=0` (preserves `last_played_at` for ordering)      |
+
+After every write, emit `playbackHistoryChanged(dto)` to subscribed clients.
+
+## Test shape
+
+The foundation ticket lands these test groups. Other Phase 1 tickets reuse
+the harnesses.
+
+### Schema tests (Packages/EngineStore)
+
+- `MigrationV2Tests`:
+  - Fresh DB → both V1 and V2 apply cleanly; `completed_at` column exists.
+  - Idempotent: running V2 twice is a no-op.
+  - V1-only DB → V2 applies; existing rows have `completed_at = NULL`.
+- `PlaybackHistoryRecordV2Tests`:
+  - Round-trip insert/fetch with `completedAt = nil` and `completedAt = 1234`.
+
+### DTO tests (Packages/EngineInterface)
+
+- `PlaybackHistoryDTOTests`:
+  - NSSecureCoding round-trip with all `completedAt` shapes.
+  - `schemaVersion = 1` constant.
+
+### Mapping tests (Packages/XPCMapping)
+
+- `PlaybackHistoryMappingTests`:
+  - Domain → DTO → domain idempotent for all rows in the derivation matrix.
+
+### Domain tests (Packages/LibraryDomain — new)
+
+- `WatchStatusDerivationTests`:
+  - One case per row in the derivation matrix above (≥ 7 cases).
+- `WatchStateMachineTests`:
+  - One case per cell in the transition matrix (4 × 5 = 20 base cases).
+  - Idempotence: applying the same event twice from a stable state is a
+    no-op where the matrix says so.
+  - Threshold edge: `b == ceil(0.95 * T)` crosses; `b == ceil(0.95*T) - 1`
+    does not.
+  - Invariant-violation rows produce the documented fallback, never crash.
+
+### Engine write-path tests (EngineService)
+
+- `CacheManagerWatchStateTests`:
+  - 0→1 transition sets `completed_at` to the injected `now`.
+  - Re-completion during re-watch updates `completed_at`.
+  - Manual mark-watched on absent row creates correct shape.
+  - Manual mark-unwatched preserves `last_played_at`.
+  - `playbackHistoryChanged` event is emitted exactly once per write.
+
+### XPC integration test (Packages/EngineInterface)
+
+- `XPCPlaybackHistoryTests` (extends the in-process `MockEngineServer`):
+  - `listPlaybackHistory` returns `[]` against an empty fake.
+  - After a synthetic write, the next call returns the inserted row, and
+    the subscribed event fires once.
+
+## Out of scope for the foundation
+
+- Library UI changes (continue-watching row, watched badge, heart toggle,
+  context menu) — those are #35/#36/#37.
+- The `favourites` table — independent engine task `T-STORE-FAVOURITES`,
+  filed in `TASKS.md` as part of this design pass.
+- Snapshot tests for any UI surface — none in this PR.
+- Trakt/sync-side conflict rules — explicitly Phase 2+ per `docs/v1-roadmap.md`.
+
+## Risks and mitigations
+
+| Risk                                                                 | Mitigation                                                                                                |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Engine and app drift on the threshold formula                        | Single helper `WatchThreshold.isComplete(progress:total:)` exported from `LibraryDomain`, used by both    |
+| `playbackHistoryChanged` storm during heavy seek                     | Engine writes are already throttled to 15 s ticks + close; event piggy-backs on the same write           |
+| `completed_at` lost on V2 migration of a populated production DB     | Migration is additive; rows preserve `completed`. Loss of historical `completed_at` is acceptable for v1 |
+| Re-watch UI confusion ("why does this say 'Watched yesterday' when I'm at 50%?") | `.reWatching` carries `previouslyCompletedAt` so UI can pick the right copy ("Re-watching, last finished yesterday") |
+| Future v2 wants per-watch event log (drop "most-recent wins" rule)   | Not blocked by this design — adding an `episodes_watched` table would supplement, not contradict, `completed_at` |

--- a/docs/v1-roadmap.md
+++ b/docs/v1-roadmap.md
@@ -26,7 +26,8 @@ All engine dependencies for p0 work are in place:
 - Phase 6 UI foundations (`T-UI-LIBRARY`, `T-UI-PLAYER`, `T-UI-HEALTH-HUD`) DONE — brand-compliant library and player shells are built and reviewed.
 
 **Missing engine seams** that may surface during p0 execution (each gets a fresh engine issue when encountered):
-- `favourites` table (Epic #5 — #36 needs it).
+- `favourites` table (Epic #5 — #36 needs it). **Filed as `T-STORE-FAVOURITES` in `TASKS.md` Phase 8 during the Phase 1 design pass (2026-04-16).**
+- `playback_history.completed_at` column + `listPlaybackHistory` / `playbackHistoryChanged` XPC surface (Epic #5 — #34 foundation). **Bundled into the #34 foundation PR per `docs/design/watch-state-foundation.md`; spec 05 → rev 5, addendum A26.**
 - Watched-seconds reporting path (spec 05 § exclusion list; anchored in spec 03 exclusion list per F6 — v1.1).
 - Episode metadata association with `playback_history` (Epic #2 + #5 interaction).
 
@@ -44,12 +45,12 @@ Every phase follows the same protocol:
 
 **Why first:** smallest surface, most engine-adjacent, strengthens the existing library/player shells without touching new external services. A credible Phase 1 is a proof that the phased approach works.
 
-**Foundation:** **#34** — watched-state transitions (`in-progress → watched → re-watching`). Defines `WatchStatus` enum, the state machine, and the domain→DTO path for watch state events.
+**Foundation:** **#34** — watched-state transitions (`in-progress → watched → re-watching`). Defines `WatchStatus` enum, the deterministic transition state machine, the new `Packages/LibraryDomain` package, the `completed_at` schema column (V2 migration; spec 05 rev 5; addendum A26), and the `listPlaybackHistory` + `playbackHistoryChanged` XPC additions. **Full design:** [`docs/design/watch-state-foundation.md`](design/watch-state-foundation.md).
 
 **Dependent tickets (merge after foundation):**
-- **#35** continue-watching row generation (depends on #34 state model + `playback_history` queries).
-- **#37** manual mark-watched / mark-unwatched actions (depends on #34 transitions).
-- **#36** favourites with new schema table (independent of #34; needs a new engine issue for the GRDB `favourites` table migration — to be created during the Opus design pass).
+- **#35** continue-watching row generation (depends on #34 state model + `listPlaybackHistory` / `playbackHistoryChanged` XPC surface).
+- **#37** manual mark-watched / mark-unwatched actions (depends on #34 transitions + the new `setWatchedState` XPC method introduced alongside).
+- **#36** favourites with new schema table (independent of #34; depends on engine task `T-STORE-FAVOURITES` in `TASKS.md` Phase 8).
 
 **Deferred / reassigned:**
 - **#72** (macOS: drag-and-drop subtitle files) is labelled `module:macos` but is functionally the same as **#28** (Subtitles: drag-and-drop SRT ingestion onto player). Consolidate in Phase 2 — likely close #72 as duplicate of #28 or split into "drop anywhere in app" vs "drop on player window" if product decides both are needed.


### PR DESCRIPTION
## Summary

Opus design pass for Epic #5 Phase 1. Records the design that #34, #35, #36, #37 all build against, plus the spec changes the foundation will land. No code yet — that's #34.

## What changes

- **`docs/design/watch-state-foundation.md`** (new) — full design: `WatchStatus` enum, deterministic transition matrix, DTO derivation matrix, engine write rules, test shape, risks.
- **Spec 05 → rev 5** — adds `playback_history.completed_at INTEGER NULL`, manual mark-watched/unwatched semantics, and the `playbackHistoryChanged` emit rule.
- **Addendum A26** — full rationale for the schema bump and the new `listPlaybackHistory` / `playbackHistoryChanged` XPC contract additions (versioned per A1).
- **`TASKS.md` Phase 8** — new engine task `T-STORE-FAVOURITES` (additive `favourites` table migration; independent of #34; unblocks #36).
- **`docs/v1-roadmap.md`** — cross-links to the design doc and the new engine task.

## Key decisions (recorded in the doc)

1. `WatchStatus` carries a real `completedAt: Date` — schema bump over approximation.
2. Progress is byte-accurate, not seconds (matches spec 05 rev 4 / A6).
3. `WatchStatus` is app-side; engine writes raw rows.
4. Re-watch is derived from `(completed=1 AND resumeByteOffset>0)`, not stored.
5. `WatchStateMachine` is a pure function with injected `now: Date` (mirrors planner discipline / A3).

## Test plan

- [x] No code touched in this PR; tests for the foundation arrive in #34.
- [x] Spec rev/addendum cross-references verified.
- [x] Roadmap cross-link to the design doc verified.

Refs #5, #34, #35, #36, #37