### PR TITLE
feat(library): WatchStatus foundation (epic #5 phase 1, #34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           swift test --package-path Packages/EngineInterface
           swift test --package-path Packages/XPCMapping
           swift test --package-path Packages/EngineStore
+          swift test --package-path Packages/LibraryDomain
 
       - name: Snapshot tests (advisory — pixel drift on CI vs local)
         # CI runners don't have the owner's personal signing certificate for

--- a/App/Shared/DTOSendable.swift
+++ b/App/Shared/DTOSendable.swift
@@ -17,3 +17,4 @@ extension FileAvailabilityDTO: @unchecked @retroactive Sendable {}
 extension StreamHealthDTO: @unchecked @retroactive Sendable {}
 extension DiskPressureDTO: @unchecked @retroactive Sendable {}
 extension ByteRangeDTO: @unchecked @retroactive Sendable {}
+extension PlaybackHistoryDTO: @unchecked @retroactive Sendable {}

--- a/App/Shared/EngineClient.swift
+++ b/App/Shared/EngineClient.swift
@@ -327,6 +327,53 @@ public actor EngineClient {
         }
     }
 
+    // MARK: - Watch state (A26 — Epic #5 Phase 1 foundation)
+
+    /// Returns the engine's current `playback_history` snapshot.
+    public func listPlaybackHistory() async throws -> [PlaybackHistoryDTO] {
+        return try await withCheckedThrowingContinuation { cont in
+            let resumer = ContinuationResumer(cont)
+
+            let p: any EngineXPC
+            do {
+                p = try proxy(method: "listPlaybackHistory", resumer: resumer)
+            } catch {
+                resumer.resume(throwing: error)
+                return
+            }
+
+            p.listPlaybackHistory { rows in
+                resumer.resume(returning: rows)
+            }
+        }
+    }
+
+    /// Manually mark a file as watched or unwatched. The engine writes the
+    /// canonical row state and emits `playbackHistoryChanged`.
+    public func setWatchedState(torrentID: NSString,
+                                fileIndex: NSNumber,
+                                watched: Bool) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let resumer = ContinuationResumer(cont)
+
+            let p: any EngineXPC
+            do {
+                p = try proxy(method: "setWatchedState", resumer: resumer)
+            } catch {
+                resumer.resume(throwing: error)
+                return
+            }
+
+            p.setWatchedState(torrentID, fileIndex: fileIndex, watched: watched) { error in
+                if let error {
+                    resumer.resume(throwing: EngineClientError.serviceError(error))
+                } else {
+                    resumer.resume(returning: ())
+                }
+            }
+        }
+    }
+
     // MARK: - Event stream access
 
     /// The event handler that receives engine-pushed events.

--- a/App/Shared/EngineEventHandler.swift
+++ b/App/Shared/EngineEventHandler.swift
@@ -28,6 +28,10 @@ public final class EngineEventHandler: NSObject, EngineEvents, @unchecked Sendab
     /// Fires whenever the cache disk-pressure level changes.
     public let diskPressureChangedSubject = PassthroughSubject<DiskPressureDTO, Never>()
 
+    /// Fires whenever a `playback_history` row is written (15 s tick during
+    /// playback, stream close, or manual mark-watched/unwatched). See A26.
+    public let playbackHistoryChangedSubject = PassthroughSubject<PlaybackHistoryDTO, Never>()
+
     // MARK: EngineEvents conformance
 
     public func torrentUpdated(_ snapshot: TorrentSummaryDTO) {
@@ -44,5 +48,9 @@ public final class EngineEventHandler: NSObject, EngineEvents, @unchecked Sendab
 
     public func diskPressureChanged(_ update: DiskPressureDTO) {
         diskPressureChangedSubject.send(update)
+    }
+
+    public func playbackHistoryChanged(_ update: PlaybackHistoryDTO) {
+        playbackHistoryChangedSubject.send(update)
     }
 }

--- a/EngineService/Cache/CacheManager.swift
+++ b/EngineService/Cache/CacheManager.swift
@@ -52,37 +52,122 @@ public final class CacheManager {
 
     /// Upserts a playback_history row.
     ///
-    /// - If `resumeByteOffset >= 0.95 * fileSize`, the row is marked
-    ///   `completed = true` and the offset is reset to 0 (per spec A6).
-    /// - `lastPlayedAt` is always set to the current time (unix ms).
+    /// Behaviour matches spec 05 rev 5 § Update rules and addendum A26:
+    /// - If `resumeByteOffset >= 0.95 * fileSize`, the row's `completed` flips
+    ///   to `true`; the byte offset is reset to 0 (matches the historical
+    ///   on-completion-reset behaviour); `completed_at` is set to `now`.
+    /// - During a re-watch (`completed` already `true` at row entry, byte
+    ///   offset advancing): `completed` stays `true`, `completed_at` is
+    ///   preserved, `resumeByteOffset` tracks current progress.
+    /// - On re-completion during a re-watch (byte criterion fires again):
+    ///   `completed_at` is updated to `now` (most-recent-wins per A26).
+    /// - `lastPlayedAt` is always set to `now`.
+    /// - `totalWatchedSeconds` is preserved across upserts.
+    ///
+    /// Returns the record actually written so callers can emit
+    /// `playbackHistoryChanged` with up-to-date data.
+    @discardableResult
     public func recordPlayback(
         torrentId: String,
         fileIndex: Int,
         resumeByteOffset: Int64,
-        fileSize: Int64
-    ) throws {
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
-        let threshold = Int64(Double(fileSize) * 0.95)
-        let isComplete = resumeByteOffset >= threshold
-        let offset: Int64 = isComplete ? 0 : resumeByteOffset
+        fileSize: Int64,
+        nowMillis: Int64? = nil
+    ) throws -> PlaybackHistoryRecord {
+        let now = nowMillis ?? Int64(Date().timeIntervalSince1970 * 1000)
+        // Use integer-arithmetic threshold to match LibraryDomain's
+        // WatchThreshold helper exactly. fileSize <= 0 → never complete.
+        let isCompleteThisTick = fileSize > 0 &&
+            resumeByteOffset.multipliedReportingOverflow(by: 100).0 >=
+            fileSize.multipliedReportingOverflow(by: 95).0
 
-        var record = PlaybackHistoryRecord(
-            torrentId: torrentId,
-            fileIndex: fileIndex,
-            resumeByteOffset: offset,
-            lastPlayedAt: now,
-            totalWatchedSeconds: 0,
-            completed: isComplete
-        )
-
-        try db.write { conn in
-            // Upsert: if a row already exists, preserve totalWatchedSeconds.
-            if let existing = try PlaybackHistoryRecord
+        return try db.write { conn -> PlaybackHistoryRecord in
+            let existing = try PlaybackHistoryRecord
                 .filter(Column("torrent_id") == torrentId && Column("file_index") == fileIndex)
-                .fetchOne(conn) {
-                record.totalWatchedSeconds = existing.totalWatchedSeconds
+                .fetchOne(conn)
+
+            let wasCompleted = existing?.completed ?? false
+            // Completion sticks until manual mark-unwatched per A26.
+            let nowCompleted = wasCompleted || isCompleteThisTick
+
+            // completed_at update rule per A26 most-recent-wins:
+            //   - new completion (was=false, now=true) → now
+            //   - re-completion during re-watch (was=true, isCompleteThisTick=true) → now
+            //   - in-progress re-watch (was=true, !isCompleteThisTick) → preserve existing
+            //   - never completed → nil
+            let newCompletedAt: Int64?
+            if isCompleteThisTick {
+                newCompletedAt = now
+            } else {
+                newCompletedAt = existing?.completedAt
             }
+
+            // Reset byte offset when the byte criterion fires; otherwise track current.
+            let newOffset = isCompleteThisTick ? 0 : resumeByteOffset
+
+            var record = PlaybackHistoryRecord(
+                torrentId: torrentId,
+                fileIndex: fileIndex,
+                resumeByteOffset: newOffset,
+                lastPlayedAt: now,
+                totalWatchedSeconds: existing?.totalWatchedSeconds ?? 0,
+                completed: nowCompleted,
+                completedAt: newCompletedAt
+            )
             try record.save(conn)
+            return record
+        }
+    }
+
+    /// Manually mark a file as watched (A26 + #34 design § Engine write rules).
+    /// Inserts the row when absent. Always sets `(completed=1, completed_at=now,
+    /// resume_byte_offset=0, last_played_at=now)`. Returns the written record.
+    @discardableResult
+    public func markWatched(
+        torrentId: String,
+        fileIndex: Int,
+        nowMillis: Int64? = nil
+    ) throws -> PlaybackHistoryRecord {
+        let now = nowMillis ?? Int64(Date().timeIntervalSince1970 * 1000)
+        return try db.write { conn -> PlaybackHistoryRecord in
+            let existing = try PlaybackHistoryRecord
+                .filter(Column("torrent_id") == torrentId && Column("file_index") == fileIndex)
+                .fetchOne(conn)
+            var record = PlaybackHistoryRecord(
+                torrentId: torrentId,
+                fileIndex: fileIndex,
+                resumeByteOffset: 0,
+                lastPlayedAt: now,
+                totalWatchedSeconds: existing?.totalWatchedSeconds ?? 0,
+                completed: true,
+                completedAt: now
+            )
+            try record.save(conn)
+            return record
+        }
+    }
+
+    /// Manually mark a file as unwatched (A26 + #34 design § Engine write rules).
+    /// Sets `(completed=0, completed_at=NULL, resume_byte_offset=0)`; preserves
+    /// `last_played_at` so library ordering does not jump. No-op (returns nil)
+    /// if the row does not exist — there is nothing to clear.
+    @discardableResult
+    public func markUnwatched(
+        torrentId: String,
+        fileIndex: Int
+    ) throws -> PlaybackHistoryRecord? {
+        try db.write { conn -> PlaybackHistoryRecord? in
+            guard var record = try PlaybackHistoryRecord
+                .filter(Column("torrent_id") == torrentId && Column("file_index") == fileIndex)
+                .fetchOne(conn) else {
+                return nil
+            }
+            record.completed = false
+            record.completedAt = nil
+            record.resumeByteOffset = 0
+            // last_played_at intentionally preserved.
+            try record.save(conn)
+            return record
         }
     }
 

--- a/EngineService/Cache/CacheManagerSelfTest.swift
+++ b/EngineService/Cache/CacheManagerSelfTest.swift
@@ -396,6 +396,152 @@ func runCacheManagerSelfTests() -> [String] {
         fail("9: unexpected error: \(error)")
     }
 
+    // MARK: - 10. completed_at set on 0→1 transition (A26)
+
+    do {
+        let db = try EngineDatabase.openInMemory()
+        let cache = try CacheManager(db: db)
+        let fileSize: Int64 = 1_000_000
+
+        // Tick 1: in-progress, no completion.
+        let r1 = try cache.recordPlayback(torrentId: "ca-10", fileIndex: 0,
+                                          resumeByteOffset: 100,
+                                          fileSize: fileSize,
+                                          nowMillis: 1_000_000)
+        expect(!r1.completed, "10: tick 1 should not be completed")
+        expect(r1.completedAt == nil, "10: tick 1 should leave completed_at nil")
+
+        // Tick 2: cross threshold.
+        let r2 = try cache.recordPlayback(torrentId: "ca-10", fileIndex: 0,
+                                          resumeByteOffset: 950_000,
+                                          fileSize: fileSize,
+                                          nowMillis: 2_000_000)
+        expect(r2.completed, "10: tick 2 should be completed")
+        expect(r2.completedAt == 2_000_000,
+               "10: completed_at should be set to now on 0→1 transition, got \(r2.completedAt ?? -1)")
+        expect(r2.resumeByteOffset == 0, "10: offset should reset to 0 on completion")
+    } catch {
+        fail("10: unexpected error: \(error)")
+    }
+
+    // MARK: - 11. Re-watch preserves completed and completed_at (A26)
+
+    do {
+        let db = try EngineDatabase.openInMemory()
+        let cache = try CacheManager(db: db)
+        let fileSize: Int64 = 1_000_000
+
+        // Watch to completion.
+        try cache.recordPlayback(torrentId: "ca-11", fileIndex: 0,
+                                 resumeByteOffset: 950_000,
+                                 fileSize: fileSize,
+                                 nowMillis: 1_000_000)
+
+        // Re-open and progress (well below threshold).
+        let r = try cache.recordPlayback(torrentId: "ca-11", fileIndex: 0,
+                                         resumeByteOffset: 100_000,
+                                         fileSize: fileSize,
+                                         nowMillis: 5_000_000)
+        expect(r.completed, "11: re-watch progress must keep completed=true")
+        expect(r.completedAt == 1_000_000,
+               "11: re-watch progress must preserve completed_at, got \(r.completedAt ?? -1)")
+        expect(r.resumeByteOffset == 100_000,
+               "11: re-watch must track current offset, got \(r.resumeByteOffset)")
+    } catch {
+        fail("11: unexpected error: \(error)")
+    }
+
+    // MARK: - 12. Re-completion updates completed_at (most-recent-wins, A26)
+
+    do {
+        let db = try EngineDatabase.openInMemory()
+        let cache = try CacheManager(db: db)
+        let fileSize: Int64 = 1_000_000
+
+        try cache.recordPlayback(torrentId: "ca-12", fileIndex: 0,
+                                 resumeByteOffset: 950_000,
+                                 fileSize: fileSize,
+                                 nowMillis: 1_000_000)
+        // Some time later, re-watch ends with full completion again.
+        let r = try cache.recordPlayback(torrentId: "ca-12", fileIndex: 0,
+                                         resumeByteOffset: 980_000,
+                                         fileSize: fileSize,
+                                         nowMillis: 9_000_000)
+        expect(r.completed, "12: re-completion must keep completed=true")
+        expect(r.completedAt == 9_000_000,
+               "12: re-completion must update completed_at to now, got \(r.completedAt ?? -1)")
+        expect(r.resumeByteOffset == 0, "12: re-completion resets offset to 0")
+    } catch {
+        fail("12: unexpected error: \(error)")
+    }
+
+    // MARK: - 13. markWatched on absent row inserts the correct shape
+
+    do {
+        let db = try EngineDatabase.openInMemory()
+        let cache = try CacheManager(db: db)
+
+        let r = try cache.markWatched(torrentId: "ca-13", fileIndex: 4,
+                                      nowMillis: 5_555_555)
+        expect(r.completed, "13: marked-watched row must have completed=true")
+        expect(r.completedAt == 5_555_555,
+               "13: completed_at should equal injected now, got \(r.completedAt ?? -1)")
+        expect(r.resumeByteOffset == 0, "13: resume offset must be 0")
+        expect(r.lastPlayedAt == 5_555_555, "13: last_played_at must be set on insert")
+
+        let fetched = try cache.fetchHistory(torrentId: "ca-13", fileIndex: 4)
+        expect(fetched != nil, "13: row should be persisted")
+    } catch {
+        fail("13: unexpected error: \(error)")
+    }
+
+    // MARK: - 14. markWatched on already-watched row re-stamps completed_at
+
+    do {
+        let db = try EngineDatabase.openInMemory()
+        let cache = try CacheManager(db: db)
+
+        try cache.markWatched(torrentId: "ca-14", fileIndex: 0, nowMillis: 1_000)
+        let r = try cache.markWatched(torrentId: "ca-14", fileIndex: 0, nowMillis: 2_000)
+        expect(r.completedAt == 2_000,
+               "14: a fresh markWatched call must update completed_at, got \(r.completedAt ?? -1)")
+    } catch {
+        fail("14: unexpected error: \(error)")
+    }
+
+    // MARK: - 15. markUnwatched clears completion and preserves last_played_at
+
+    do {
+        let db = try EngineDatabase.openInMemory()
+        let cache = try CacheManager(db: db)
+
+        try cache.markWatched(torrentId: "ca-15", fileIndex: 0, nowMillis: 1_000)
+        let r = try cache.markUnwatched(torrentId: "ca-15", fileIndex: 0)
+        guard let r = r else {
+            fail("15: markUnwatched should return a record when one exists")
+            return failures
+        }
+        expect(!r.completed, "15: completed must flip to false")
+        expect(r.completedAt == nil, "15: completed_at must be cleared")
+        expect(r.resumeByteOffset == 0, "15: resume offset must be 0")
+        expect(r.lastPlayedAt == 1_000,
+               "15: last_played_at must be preserved (was 1000), got \(r.lastPlayedAt)")
+    } catch {
+        fail("15: unexpected error: \(error)")
+    }
+
+    // MARK: - 16. markUnwatched on absent row is a no-op (returns nil)
+
+    do {
+        let db = try EngineDatabase.openInMemory()
+        let cache = try CacheManager(db: db)
+
+        let r = try cache.markUnwatched(torrentId: "ca-16-missing", fileIndex: 0)
+        expect(r == nil, "16: markUnwatched on absent row must return nil")
+    } catch {
+        fail("16: unexpected error: \(error)")
+    }
+
     return failures
 }
 

--- a/EngineService/XPC/EngineXPCServer.swift
+++ b/EngineService/XPC/EngineXPCServer.swift
@@ -91,6 +91,28 @@ import EngineInterface
         reply()
     }
 
+    // MARK: - Watch state (A26 — Epic #5 Phase 1 foundation)
+
+    func listPlaybackHistory(_ reply: @escaping ([PlaybackHistoryDTO]) -> Void) {
+        reply(backend.listPlaybackHistory())
+    }
+
+    func setWatchedState(_ torrentID: NSString,
+                         fileIndex: NSNumber,
+                         watched: Bool,
+                         reply: @escaping (NSError?) -> Void) {
+        do {
+            try backend.setWatchedState(
+                torrentID: torrentID as String,
+                fileIndex: fileIndex.intValue,
+                watched: watched
+            )
+            reply(nil)
+        } catch {
+            reply(error as NSError)
+        }
+    }
+
     // MARK: - Event subscription
 
     func subscribe(_ client: EngineEvents,

--- a/EngineService/XPC/FakeEngineBackend.swift
+++ b/EngineService/XPC/FakeEngineBackend.swift
@@ -150,6 +150,56 @@ final class FakeEngineBackend: EngineXPCBackend {
         }
     }
 
+    // MARK: - Watch state (A26)
+    //
+    // The fake backend is in-memory only — no GRDB. It tracks a small map of
+    // "fake" playback rows keyed by "\(torrentID)#\(fileIndex)". Engine write
+    // semantics (completed_at on 0→1, preserved on re-watch, etc.) are mirrored
+    // here so the app sees a realistic XPC contract under `--fake-backend`.
+
+    /// torrentID#fileIndex → in-memory PlaybackHistoryDTO.
+    private var fakePlaybackHistory: [String: PlaybackHistoryDTO] = [:]
+
+    func listPlaybackHistory() -> [PlaybackHistoryDTO] {
+        queue.sync { Array(fakePlaybackHistory.values) }
+    }
+
+    func setWatchedState(torrentID: String, fileIndex: Int, watched: Bool) throws {
+        let key = "\(torrentID)#\(fileIndex)"
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let dto = queue.sync { () -> PlaybackHistoryDTO in
+            let existing = fakePlaybackHistory[key]
+            let next: PlaybackHistoryDTO
+            if watched {
+                next = PlaybackHistoryDTO(
+                    torrentID: torrentID as NSString,
+                    fileIndex: Int32(clamping: fileIndex),
+                    resumeByteOffset: 0,
+                    lastPlayedAt: nowMs,
+                    totalWatchedSeconds: existing?.totalWatchedSeconds ?? 0,
+                    completed: true,
+                    completedAt: NSNumber(value: nowMs)
+                )
+            } else {
+                next = PlaybackHistoryDTO(
+                    torrentID: torrentID as NSString,
+                    fileIndex: Int32(clamping: fileIndex),
+                    resumeByteOffset: 0,
+                    lastPlayedAt: existing?.lastPlayedAt ?? nowMs,
+                    totalWatchedSeconds: existing?.totalWatchedSeconds ?? 0,
+                    completed: false,
+                    completedAt: nil
+                )
+            }
+            fakePlaybackHistory[key] = next
+            return next
+        }
+        // Mirror RealEngineBackend: emit the change event off the serial queue.
+        queue.async { [weak self] in
+            self?.clientProxy?.playbackHistoryChanged(dto)
+        }
+    }
+
     // MARK: - Private helpers
 
     private func extractName(from magnet: String) -> String? {

--- a/EngineService/XPC/RealEngineBackend.swift
+++ b/EngineService/XPC/RealEngineBackend.swift
@@ -18,6 +18,10 @@ protocol EngineXPCBackend: AnyObject {
     func openStream(torrentID: String, fileIndex: Int) throws -> StreamDescriptorDTO
     func closeStream(_ streamID: String)
     func subscribe(client: EngineEvents & NSObjectProtocol)
+
+    // Watch state (A26 — Epic #5 Phase 1 foundation)
+    func listPlaybackHistory() -> [PlaybackHistoryDTO]
+    func setWatchedState(torrentID: String, fileIndex: Int, watched: Bool) throws
 }
 
 // MARK: - RealEngineBackend
@@ -255,6 +259,52 @@ final class RealEngineBackend: EngineXPCBackend {
         eventProxy = client
         alertDispatcher.setClient(client)
         alertDispatcher.startListening()
+    }
+
+    // MARK: - Watch state (A26 — Epic #5 Phase 1 foundation)
+
+    func listPlaybackHistory() -> [PlaybackHistoryDTO] {
+        guard let cm = cacheManager else { return [] }
+        let rows = (try? cm.fetchAllHistory()) ?? []
+        return rows.map { dto(from: $0) }
+    }
+
+    func setWatchedState(torrentID: String, fileIndex: Int, watched: Bool) throws {
+        guard let cm = cacheManager else {
+            throw NSError(
+                domain: EngineErrorDomain,
+                code: EngineErrorCode.notImplemented.rawValue,
+                userInfo: [NSLocalizedDescriptionKey: "Cache manager unavailable"]
+            )
+        }
+        let written: PlaybackHistoryRecord?
+        if watched {
+            written = try cm.markWatched(torrentId: torrentID, fileIndex: fileIndex)
+        } else {
+            written = try cm.markUnwatched(torrentId: torrentID, fileIndex: fileIndex)
+        }
+        if let record = written {
+            // Emit on the same queue the rest of the engine writes from so
+            // observers see the event after the DB has settled.
+            queue.async { [weak self] in
+                guard let self = self else { return }
+                self.eventProxy?.playbackHistoryChanged(self.dto(from: record))
+            }
+        }
+    }
+
+    /// Build a `PlaybackHistoryDTO` from an `EngineStore` record. Local helper to
+    /// avoid pulling `XPCMapping` into this file's import surface twice.
+    private func dto(from record: PlaybackHistoryRecord) -> PlaybackHistoryDTO {
+        PlaybackHistoryDTO(
+            torrentID: record.torrentId as NSString,
+            fileIndex: Int32(clamping: record.fileIndex),
+            resumeByteOffset: record.resumeByteOffset,
+            lastPlayedAt: record.lastPlayedAt,
+            totalWatchedSeconds: record.totalWatchedSeconds,
+            completed: record.completed,
+            completedAt: record.completedAt.map { NSNumber(value: $0) }
+        )
     }
 
     // MARK: - Eviction timer

--- a/Packages/EngineInterface/Sources/EngineInterface/EngineEventsProtocol.swift
+++ b/Packages/EngineInterface/Sources/EngineInterface/EngineEventsProtocol.swift
@@ -8,4 +8,9 @@ import Foundation
     func fileAvailabilityChanged(_ update: FileAvailabilityDTO)
     func streamHealthChanged(_ update: StreamHealthDTO)
     func diskPressureChanged(_ update: DiskPressureDTO)
+
+    /// Emitted exactly once per `playback_history` row write (15 s tick during
+    /// playback, stream close, or manual mark-watched / mark-unwatched).
+    /// See spec 05 § Update rules and addendum A26.
+    func playbackHistoryChanged(_ update: PlaybackHistoryDTO)
 }

--- a/Packages/EngineInterface/Sources/EngineInterface/EngineXPCProtocol.swift
+++ b/Packages/EngineInterface/Sources/EngineInterface/EngineXPCProtocol.swift
@@ -37,6 +37,24 @@ import Foundation
     func closeStream(_ streamID: NSString,
                      reply: @escaping () -> Void)
 
+    // MARK: Watch state (A26 — Epic #5 Phase 1 foundation)
+
+    /// Returns every row from `playback_history`. Empty when the table is empty.
+    /// Used by the library to derive `WatchStatus` for every known file.
+    func listPlaybackHistory(_ reply: @escaping ([PlaybackHistoryDTO]) -> Void)
+
+    /// Manually mark a file as watched (`true`) or unwatched (`false`).
+    /// See spec 05 § Update rules and `docs/design/watch-state-foundation.md`
+    /// § Engine write rules.
+    /// - Mark-watched: `(completed=1, completed_at=now, resume_byte_offset=0)`.
+    /// - Mark-unwatched: `(completed=0, completed_at=NULL, resume_byte_offset=0)`;
+    ///   `last_played_at` preserved.
+    /// Inserts the row when absent.
+    func setWatchedState(_ torrentID: NSString,
+                         fileIndex: NSNumber,
+                         watched: Bool,
+                         reply: @escaping (NSError?) -> Void)
+
     // MARK: Event subscription
 
     func subscribe(_ client: EngineEvents,

--- a/Packages/EngineInterface/Sources/EngineInterface/PlaybackHistoryDTO.swift
+++ b/Packages/EngineInterface/Sources/EngineInterface/PlaybackHistoryDTO.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Versioned XPC projection of a `playback_history` row (spec 05 rev 5,
+/// addendum A26). Carries every column on the table so the app can derive
+/// `WatchStatus` without re-querying the engine.
+///
+/// `completedAt` is `nil` until the file's first completion or after a
+/// manual mark-unwatched. `totalWatchedSeconds` stays at 0 in v1 (column
+/// reserved for v1.1).
+@objc(PlaybackHistoryDTO)
+public final class PlaybackHistoryDTO: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { true }
+
+    public let schemaVersion: Int32
+    public let torrentID: NSString
+    public let fileIndex: Int32
+    public let resumeByteOffset: Int64
+    public let lastPlayedAt: Int64
+    public let totalWatchedSeconds: Double
+    public let completed: Bool
+    /// Unix milliseconds of the most recent completion; `nil` if never completed.
+    public let completedAt: NSNumber?
+
+    public init(
+        torrentID: NSString,
+        fileIndex: Int32,
+        resumeByteOffset: Int64,
+        lastPlayedAt: Int64,
+        totalWatchedSeconds: Double,
+        completed: Bool,
+        completedAt: NSNumber?
+    ) {
+        self.schemaVersion = 1
+        self.torrentID = torrentID
+        self.fileIndex = fileIndex
+        self.resumeByteOffset = resumeByteOffset
+        self.lastPlayedAt = lastPlayedAt
+        self.totalWatchedSeconds = totalWatchedSeconds
+        self.completed = completed
+        self.completedAt = completedAt
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(schemaVersion, forKey: "schemaVersion")
+        coder.encode(torrentID, forKey: "torrentID")
+        coder.encode(fileIndex, forKey: "fileIndex")
+        coder.encode(resumeByteOffset, forKey: "resumeByteOffset")
+        coder.encode(lastPlayedAt, forKey: "lastPlayedAt")
+        coder.encode(totalWatchedSeconds, forKey: "totalWatchedSeconds")
+        coder.encode(completed, forKey: "completed")
+        coder.encode(completedAt, forKey: "completedAt")
+    }
+
+    public required init?(coder: NSCoder) {
+        schemaVersion = coder.decodeInt32(forKey: "schemaVersion")
+        guard let torrentID = coder.decodeObject(of: NSString.self, forKey: "torrentID") else { return nil }
+        fileIndex = coder.decodeInt32(forKey: "fileIndex")
+        resumeByteOffset = coder.decodeInt64(forKey: "resumeByteOffset")
+        lastPlayedAt = coder.decodeInt64(forKey: "lastPlayedAt")
+        totalWatchedSeconds = coder.decodeDouble(forKey: "totalWatchedSeconds")
+        completed = coder.decodeBool(forKey: "completed")
+        completedAt = coder.decodeObject(of: NSNumber.self, forKey: "completedAt")
+        self.torrentID = torrentID
+    }
+}

--- a/Packages/EngineInterface/Sources/EngineInterface/XPCInterfaceFactory.swift
+++ b/Packages/EngineInterface/Sources/EngineInterface/XPCInterfaceFactory.swift
@@ -46,6 +46,13 @@ public enum XPCInterfaceFactory {
     /// closeStream(_:reply:)
     ///   (reply is Void — no registration needed)
     ///
+    /// listPlaybackHistory(_:)
+    ///   reply arg 0 — [PlaybackHistoryDTO]  (NSArray<PlaybackHistoryDTO>)
+    ///   PlaybackHistoryDTO.completedAt is NSNumber? — register NSNumber too.
+    ///
+    /// setWatchedState(_:fileIndex:watched:reply:)
+    ///   (reply has only NSError? — no custom class registration needed)
+    ///
     /// subscribe(_:reply:)
     ///   arg 0 — EngineEvents proxy (set via setInterface, not setClasses)
     public static func engineInterface() -> NSXPCInterface {
@@ -99,6 +106,18 @@ public enum XPCInterfaceFactory {
             ofReply: true
         )
 
+        // listPlaybackHistory(_:) — reply arg 0: [PlaybackHistoryDTO]
+        // PlaybackHistoryDTO carries an NSNumber? for completedAt.
+        interface.setClasses(
+            [h(NSArray.self), h(PlaybackHistoryDTO.self), h(NSNumber.self)],
+            for: #selector(EngineXPC.listPlaybackHistory(_:)),
+            argumentIndex: 0,
+            ofReply: true
+        )
+
+        // setWatchedState(_:fileIndex:watched:reply:) — reply only carries
+        // NSError?. No custom-class registration needed.
+
         // subscribe(_:reply:) — arg 0: EngineEvents proxy
         // Use setInterface so XPC knows to create a proxy object rather than deserialise a plain value.
         interface.setInterface(
@@ -119,6 +138,7 @@ public enum XPCInterfaceFactory {
     /// fileAvailabilityChanged(_:) — arg 0: FileAvailabilityDTO (contains [ByteRangeDTO])
     /// streamHealthChanged(_:)     — arg 0: StreamHealthDTO
     /// diskPressureChanged(_:)     — arg 0: DiskPressureDTO
+    /// playbackHistoryChanged(_:)  — arg 0: PlaybackHistoryDTO (contains NSNumber? for completedAt)
     public static func eventsInterface() -> NSXPCInterface {
         let interface = NSXPCInterface(with: EngineEvents.self)
 
@@ -152,6 +172,15 @@ public enum XPCInterfaceFactory {
         interface.setClasses(
             [h(DiskPressureDTO.self)],
             for: #selector(EngineEvents.diskPressureChanged(_:)),
+            argumentIndex: 0,
+            ofReply: false
+        )
+
+        // playbackHistoryChanged(_:) — arg 0: PlaybackHistoryDTO
+        // PlaybackHistoryDTO carries an NSNumber? for completedAt.
+        interface.setClasses(
+            [h(PlaybackHistoryDTO.self), h(NSNumber.self)],
+            for: #selector(EngineEvents.playbackHistoryChanged(_:)),
             argumentIndex: 0,
             ofReply: false
         )

--- a/Packages/EngineInterface/Tests/EngineInterfaceTests/EngineInterfaceTests.swift
+++ b/Packages/EngineInterface/Tests/EngineInterfaceTests/EngineInterfaceTests.swift
@@ -362,3 +362,64 @@ final class DiskPressureDTOTests: XCTestCase {
         XCTAssertEqual(decoded.evictableBytes, 0)
     }
 }
+
+// MARK: - PlaybackHistoryDTO (A26)
+
+final class PlaybackHistoryDTOTests: XCTestCase {
+
+    func testRoundTrip_allFields_completedAtSet() throws {
+        let dto = PlaybackHistoryDTO(
+            torrentID: "ph-watched",
+            fileIndex: 0,
+            resumeByteOffset: 9_500_000,
+            lastPlayedAt: 1_700_000_010_000,
+            totalWatchedSeconds: 0,
+            completed: true,
+            completedAt: 1_700_000_012_345
+        )
+        let decoded = try roundTrip(dto)
+
+        XCTAssertEqual(decoded.schemaVersion, 1)
+        XCTAssertEqual(decoded.torrentID, "ph-watched")
+        XCTAssertEqual(decoded.fileIndex, 0)
+        XCTAssertEqual(decoded.resumeByteOffset, 9_500_000)
+        XCTAssertEqual(decoded.lastPlayedAt, 1_700_000_010_000)
+        XCTAssertEqual(decoded.completed, true)
+        XCTAssertEqual(decoded.completedAt?.int64Value, 1_700_000_012_345)
+    }
+
+    func testRoundTrip_completedAtNil() throws {
+        let dto = PlaybackHistoryDTO(
+            torrentID: "ph-in-progress",
+            fileIndex: 2,
+            resumeByteOffset: 1024,
+            lastPlayedAt: 1_700_000_011_000,
+            totalWatchedSeconds: 0,
+            completed: false,
+            completedAt: nil
+        )
+        let decoded = try roundTrip(dto)
+
+        XCTAssertEqual(decoded.completed, false)
+        XCTAssertNil(decoded.completedAt)
+        XCTAssertEqual(decoded.fileIndex, 2)
+        XCTAssertEqual(decoded.resumeByteOffset, 1024)
+    }
+
+    func testRoundTrip_zeroResumeWithCompleted() throws {
+        // Watched + reset on next open: completed=1, completedAt=T, resume=0.
+        let dto = PlaybackHistoryDTO(
+            torrentID: "ph-fresh-watched",
+            fileIndex: 0,
+            resumeByteOffset: 0,
+            lastPlayedAt: 1_700_000_020_000,
+            totalWatchedSeconds: 0,
+            completed: true,
+            completedAt: 1_700_000_021_000
+        )
+        let decoded = try roundTrip(dto)
+        XCTAssertEqual(decoded.resumeByteOffset, 0)
+        XCTAssertEqual(decoded.completed, true)
+        XCTAssertEqual(decoded.completedAt?.int64Value, 1_700_000_021_000)
+    }
+}

--- a/Packages/EngineInterface/Tests/EngineInterfaceTests/XPCIntegrationTests.swift
+++ b/Packages/EngineInterface/Tests/EngineInterfaceTests/XPCIntegrationTests.swift
@@ -27,9 +27,16 @@ private final class MockEngineServer: NSObject, EngineXPC {
     private var torrents: [String: TorrentSummaryDTO] = [:]
     private var files: [String: [TorrentFileDTO]] = [:]
     private var streams: [String: StreamDescriptorDTO] = [:]
+    /// Keyed by "\(torrentID)#\(fileIndex)".
+    private var playbackHistory: [String: PlaybackHistoryDTO] = [:]
+    /// Injected for the watch-state tests so `setWatchedState` is deterministic.
+    var nowMillis: Int64 = 1_700_000_000_000
 
     // Collected events for test assertion.
     var receivedUpdates: [TorrentSummaryDTO] = []
+    /// Subscribed clients for the in-process pump (mirrors how the real backend
+    /// retains a single weak proxy; a single-element array suffices here).
+    private weak var subscribedClient: EngineEvents?
 
     // MARK: EngineXPC conformance
 
@@ -151,6 +158,48 @@ private final class MockEngineServer: NSObject, EngineXPC {
 
     func subscribe(_ client: EngineEvents,
                    reply: @escaping (NSError?) -> Void) {
+        subscribedClient = client
+        reply(nil)
+    }
+
+    // MARK: Watch state (A26)
+
+    func listPlaybackHistory(_ reply: @escaping ([PlaybackHistoryDTO]) -> Void) {
+        reply(Array(playbackHistory.values))
+    }
+
+    func setWatchedState(_ torrentID: NSString,
+                         fileIndex: NSNumber,
+                         watched: Bool,
+                         reply: @escaping (NSError?) -> Void) {
+        let id = torrentID as String
+        let fi = fileIndex.int32Value
+        let key = "\(id)#\(fi)"
+        let existing = playbackHistory[key]
+        let dto: PlaybackHistoryDTO
+        if watched {
+            dto = PlaybackHistoryDTO(
+                torrentID: torrentID,
+                fileIndex: fi,
+                resumeByteOffset: 0,
+                lastPlayedAt: nowMillis,
+                totalWatchedSeconds: existing?.totalWatchedSeconds ?? 0,
+                completed: true,
+                completedAt: NSNumber(value: nowMillis)
+            )
+        } else {
+            dto = PlaybackHistoryDTO(
+                torrentID: torrentID,
+                fileIndex: fi,
+                resumeByteOffset: 0,
+                lastPlayedAt: existing?.lastPlayedAt ?? nowMillis,
+                totalWatchedSeconds: existing?.totalWatchedSeconds ?? 0,
+                completed: false,
+                completedAt: nil
+            )
+        }
+        playbackHistory[key] = dto
+        subscribedClient?.playbackHistoryChanged(dto)
         reply(nil)
     }
 
@@ -197,6 +246,7 @@ private final class FakeEventReceiver: NSObject, EngineEvents {
     var fileAvailabilityUpdates: [FileAvailabilityDTO] = []
     var streamHealthUpdates: [StreamHealthDTO] = []
     var diskPressureUpdates: [DiskPressureDTO] = []
+    var playbackHistoryUpdates: [PlaybackHistoryDTO] = []
 
     func torrentUpdated(_ snapshot: TorrentSummaryDTO) {
         torrentUpdates.append(snapshot)
@@ -212,6 +262,10 @@ private final class FakeEventReceiver: NSObject, EngineEvents {
 
     func diskPressureChanged(_ update: DiskPressureDTO) {
         diskPressureUpdates.append(update)
+    }
+
+    func playbackHistoryChanged(_ update: PlaybackHistoryDTO) {
+        playbackHistoryUpdates.append(update)
     }
 }
 
@@ -479,5 +533,80 @@ final class XPCIntegrationTests: XCTestCase {
         let decoded = try NSKeyedUnarchiver.unarchivedObject(ofClass: StreamDescriptorDTO.self, from: data)
 
         XCTAssertEqual(decoded?.resumeByteOffset, 0)
+    }
+}
+
+// MARK: - XPCPlaybackHistoryTests (A26)
+
+/// Verifies the listPlaybackHistory / setWatchedState / playbackHistoryChanged
+/// trio at the protocol surface. Mirrors the contract the real engine implements.
+final class XPCPlaybackHistoryTests: XCTestCase {
+
+    func testListPlaybackHistory_emptyByDefault() {
+        let server = MockEngineServer()
+        var result: [PlaybackHistoryDTO] = []
+        server.listPlaybackHistory { result = $0 }
+        XCTAssertTrue(result.isEmpty,
+                      "fresh server must report no playback history")
+    }
+
+    func testSetWatchedState_markWatched_insertsRowAndEmitsEvent() {
+        let server = MockEngineServer()
+        let receiver = FakeEventReceiver()
+        server.subscribe(receiver) { _ in }
+        server.nowMillis = 1_700_000_500_000
+
+        var setError: NSError?
+        server.setWatchedState(
+            "torrent-A" as NSString,
+            fileIndex: NSNumber(value: 3),
+            watched: true
+        ) { setError = $0 }
+
+        XCTAssertNil(setError)
+        XCTAssertEqual(receiver.playbackHistoryUpdates.count, 1,
+                       "exactly one playbackHistoryChanged must fire per write")
+
+        let dto = receiver.playbackHistoryUpdates[0]
+        XCTAssertEqual(dto.torrentID, "torrent-A")
+        XCTAssertEqual(dto.fileIndex, 3)
+        XCTAssertEqual(dto.completed, true)
+        XCTAssertEqual(dto.completedAt?.int64Value, 1_700_000_500_000)
+        XCTAssertEqual(dto.resumeByteOffset, 0)
+        XCTAssertEqual(dto.lastPlayedAt, 1_700_000_500_000)
+
+        // listPlaybackHistory now returns the inserted row.
+        var listed: [PlaybackHistoryDTO] = []
+        server.listPlaybackHistory { listed = $0 }
+        XCTAssertEqual(listed.count, 1)
+    }
+
+    func testSetWatchedState_markUnwatched_clearsCompletedAtAndResume() {
+        let server = MockEngineServer()
+        let receiver = FakeEventReceiver()
+        server.subscribe(receiver) { _ in }
+
+        // Seed a watched row.
+        server.nowMillis = 1_700_000_600_000
+        server.setWatchedState("torrent-B" as NSString,
+                               fileIndex: NSNumber(value: 0),
+                               watched: true) { _ in }
+
+        // Then mark it unwatched.
+        server.nowMillis = 1_700_000_700_000
+        server.setWatchedState("torrent-B" as NSString,
+                               fileIndex: NSNumber(value: 0),
+                               watched: false) { _ in }
+
+        XCTAssertEqual(receiver.playbackHistoryUpdates.count, 2,
+                       "one event per write — watched + unwatched")
+
+        let last = receiver.playbackHistoryUpdates[1]
+        XCTAssertEqual(last.completed, false)
+        XCTAssertNil(last.completedAt)
+        XCTAssertEqual(last.resumeByteOffset, 0)
+        // last_played_at preserved per spec 05 § Update rules.
+        XCTAssertEqual(last.lastPlayedAt, 1_700_000_600_000,
+                       "mark-unwatched must preserve last_played_at")
     }
 }

--- a/Packages/EngineInterface/Tests/EngineInterfaceTests/XPCInterfaceFactoryTests.swift
+++ b/Packages/EngineInterface/Tests/EngineInterfaceTests/XPCInterfaceFactoryTests.swift
@@ -162,11 +162,12 @@ final class XPCInterfaceFactoryTests: XCTestCase {
 
         // (selector, argIndex, isReply, expectedClass, label)
         let cases: [(sel: Selector, argIdx: Int, isReply: Bool, cls: AnyClass, label: String)] = [
-            (#selector(EngineXPC.addMagnet(_:reply:)),            0, true,  TorrentSummaryDTO.self,  "addMagnet reply"),
-            (#selector(EngineXPC.addTorrentFile(_:reply:)),       0, true,  TorrentSummaryDTO.self,  "addTorrentFile reply"),
-            (#selector(EngineXPC.listTorrents(_:)),               0, true,  TorrentSummaryDTO.self,  "listTorrents reply"),
-            (#selector(EngineXPC.listFiles(_:reply:)),            0, true,  TorrentFileDTO.self,     "listFiles reply"),
-            (#selector(EngineXPC.openStream(_:fileIndex:reply:)), 0, true,  StreamDescriptorDTO.self,"openStream reply"),
+            (#selector(EngineXPC.addMagnet(_:reply:)),                 0, true,  TorrentSummaryDTO.self,    "addMagnet reply"),
+            (#selector(EngineXPC.addTorrentFile(_:reply:)),            0, true,  TorrentSummaryDTO.self,    "addTorrentFile reply"),
+            (#selector(EngineXPC.listTorrents(_:)),                    0, true,  TorrentSummaryDTO.self,    "listTorrents reply"),
+            (#selector(EngineXPC.listFiles(_:reply:)),                 0, true,  TorrentFileDTO.self,       "listFiles reply"),
+            (#selector(EngineXPC.openStream(_:fileIndex:reply:)),      0, true,  StreamDescriptorDTO.self,  "openStream reply"),
+            (#selector(EngineXPC.listPlaybackHistory(_:)),             0, true,  PlaybackHistoryDTO.self,   "listPlaybackHistory reply"),
         ]
 
         for c in cases {
@@ -185,6 +186,7 @@ final class XPCInterfaceFactoryTests: XCTestCase {
             (#selector(EngineEvents.fileAvailabilityChanged(_:)), FileAvailabilityDTO.self, "fileAvailabilityChanged"),
             (#selector(EngineEvents.streamHealthChanged(_:)),     StreamHealthDTO.self,     "streamHealthChanged"),
             (#selector(EngineEvents.diskPressureChanged(_:)),     DiskPressureDTO.self,     "diskPressureChanged"),
+            (#selector(EngineEvents.playbackHistoryChanged(_:)),  PlaybackHistoryDTO.self,  "playbackHistoryChanged"),
         ]
 
         for c in cases {

--- a/Packages/EngineStore/Sources/EngineStore/EngineDatabase.swift
+++ b/Packages/EngineStore/Sources/EngineStore/EngineDatabase.swift
@@ -31,6 +31,9 @@ public enum EngineDatabase {
         migrator.registerMigration(V1Migration.identifier) { db in
             try V1Migration.perform(db)
         }
+        migrator.registerMigration(V2Migration.identifier) { db in
+            try V2Migration.perform(db)
+        }
         try migrator.migrate(queue)
     }
 }

--- a/Packages/EngineStore/Sources/EngineStore/PlaybackHistoryRecord.swift
+++ b/Packages/EngineStore/Sources/EngineStore/PlaybackHistoryRecord.swift
@@ -6,6 +6,11 @@ import GRDB
 /// successfully served by the gateway — not a time-accurate seek point
 /// (see addendum A6). `totalWatchedSeconds` stays at 0 in v1; it will be
 /// populated via XPC in v1.1 once the watched-seconds reporting path exists.
+///
+/// `completedAt` (A26) is the unix-ms timestamp of the most recent completion,
+/// set on every `completed` 0 → 1 transition (incl. re-completions during
+/// re-watches). `nil` until the file is completed for the first time, or
+/// after a manual mark-unwatched.
 public struct PlaybackHistoryRecord: Codable, FetchableRecord, PersistableRecord {
     public static let databaseTableName = "playback_history"
 
@@ -17,6 +22,7 @@ public struct PlaybackHistoryRecord: Codable, FetchableRecord, PersistableRecord
         case lastPlayedAt = "last_played_at"
         case totalWatchedSeconds = "total_watched_seconds"
         case completed
+        case completedAt = "completed_at"
     }
 
     /// Torrent info-hash or stable identifier, as assigned by libtorrent.
@@ -35,9 +41,14 @@ public struct PlaybackHistoryRecord: Codable, FetchableRecord, PersistableRecord
     /// Cumulative seconds of video watched; populated from CMTime observations in v1.1.
     public var totalWatchedSeconds: Double
 
-    /// `true` when `resumeByteOffset >= 0.95 * file_size` at stream close.
+    /// `true` when `resumeByteOffset >= 0.95 * file_size` at stream close,
+    /// or set explicitly by manual mark-watched.
     /// Stored as INTEGER (0/1) by GRDB's Codable bridge.
     public var completed: Bool
+
+    /// Unix milliseconds of the most recent completion. `nil` until first
+    /// completion; cleared by manual mark-unwatched. See A26.
+    public var completedAt: Int64?
 
     public init(
         torrentId: String,
@@ -45,7 +56,8 @@ public struct PlaybackHistoryRecord: Codable, FetchableRecord, PersistableRecord
         resumeByteOffset: Int64,
         lastPlayedAt: Int64,
         totalWatchedSeconds: Double = 0,
-        completed: Bool = false
+        completed: Bool = false,
+        completedAt: Int64? = nil
     ) {
         self.torrentId = torrentId
         self.fileIndex = fileIndex
@@ -53,5 +65,6 @@ public struct PlaybackHistoryRecord: Codable, FetchableRecord, PersistableRecord
         self.lastPlayedAt = lastPlayedAt
         self.totalWatchedSeconds = totalWatchedSeconds
         self.completed = completed
+        self.completedAt = completedAt
     }
 }

--- a/Packages/EngineStore/Sources/EngineStore/V2Migration.swift
+++ b/Packages/EngineStore/Sources/EngineStore/V2Migration.swift
@@ -1,0 +1,22 @@
+import GRDB
+
+/// Adds the `playback_history.completed_at` column for the Epic #5 Phase 1
+/// foundation (#34). See spec 05 rev 5 § Schema and addendum A26.
+///
+/// Additive and backward-compatible: existing rows get `NULL` for the new
+/// column and the engine fills it on the next completion. Idempotent via
+/// GRDB's named-migration tracking (identifier `v2_add_completed_at`).
+///
+/// Independent of the unrelated `v2_add_favourites` migration (TASKS.md
+/// Phase 8); migrations apply in registration order, neither blocks the
+/// other.
+enum V2Migration {
+    static let identifier = "v2_add_completed_at"
+
+    static func perform(_ db: Database) throws {
+        try db.execute(sql: """
+            ALTER TABLE playback_history
+            ADD COLUMN completed_at INTEGER
+            """)
+    }
+}

--- a/Packages/EngineStore/Tests/EngineStoreTests/MigrationTests.swift
+++ b/Packages/EngineStore/Tests/EngineStoreTests/MigrationTests.swift
@@ -61,4 +61,83 @@ final class MigrationTests: XCTestCase {
             XCTAssertEqual(identifier, "v1", "v1 migration not recorded in grdb_migrations")
         }
     }
+
+    // MARK: - V2 (A26 — completed_at column)
+
+    func testV2AddsCompletedAtColumn() throws {
+        let queue = try EngineDatabase.openInMemory()
+
+        try queue.read { db in
+            let columns = try Row.fetchAll(
+                db,
+                sql: "PRAGMA table_info(playback_history)"
+            ).compactMap { $0["name"] as String? }
+            XCTAssertTrue(columns.contains("completed_at"),
+                          "playback_history.completed_at column missing after V2 migration")
+        }
+    }
+
+    func testV2IsIdempotent() throws {
+        let queue = try DatabaseQueue()
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration(V1Migration.identifier) { db in
+            try V1Migration.perform(db)
+        }
+        migrator.registerMigration(V2Migration.identifier) { db in
+            try V2Migration.perform(db)
+        }
+        try migrator.migrate(queue)
+        try migrator.migrate(queue) // re-run; must be no-op
+
+        try queue.read { db in
+            let count = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM grdb_migrations WHERE identifier = ?",
+                arguments: [V2Migration.identifier]
+            )
+            XCTAssertEqual(count, 1, "V2 migration recorded more than once")
+        }
+    }
+
+    func testV2UpgradesV1OnlyDatabasePreservingRows() throws {
+        // Build a V1-only DB, insert a row, then apply V2 and verify the row
+        // survives with completed_at == NULL.
+        let queue = try DatabaseQueue()
+        var v1Migrator = DatabaseMigrator()
+        v1Migrator.registerMigration(V1Migration.identifier) { db in
+            try V1Migration.perform(db)
+        }
+        try v1Migrator.migrate(queue)
+
+        try queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO playback_history
+                (torrent_id, file_index, resume_byte_offset, last_played_at, total_watched_seconds, completed)
+                VALUES ('legacy-row', 0, 1024, 1700000000000, 0, 1)
+                """)
+        }
+
+        // Upgrade to V2.
+        var fullMigrator = DatabaseMigrator()
+        fullMigrator.registerMigration(V1Migration.identifier) { db in
+            try V1Migration.perform(db)
+        }
+        fullMigrator.registerMigration(V2Migration.identifier) { db in
+            try V2Migration.perform(db)
+        }
+        try fullMigrator.migrate(queue)
+
+        try queue.read { db in
+            let row = try Row.fetchOne(
+                db,
+                sql: "SELECT * FROM playback_history WHERE torrent_id = ?",
+                arguments: ["legacy-row"]
+            )
+            XCTAssertNotNil(row, "legacy row lost during V2 upgrade")
+            XCTAssertEqual(row?["resume_byte_offset"] as Int64?, 1024)
+            XCTAssertEqual(row?["completed"] as Int64?, 1)
+            XCTAssertNil(row?["completed_at"] as Int64?,
+                         "legacy row should have NULL completed_at after V2 upgrade")
+        }
+    }
 }

--- a/Packages/EngineStore/Tests/EngineStoreTests/PlaybackHistoryRecordTests.swift
+++ b/Packages/EngineStore/Tests/EngineStoreTests/PlaybackHistoryRecordTests.swift
@@ -86,6 +86,75 @@ final class PlaybackHistoryRecordTests: XCTestCase {
         XCTAssertEqual(fetched?.completed, true)
     }
 
+    // MARK: - completedAt round-trip (A26)
+
+    func testCompletedAtNilByDefault() throws {
+        let record = PlaybackHistoryRecord(
+            torrentId: "ca-nil",
+            fileIndex: 0,
+            resumeByteOffset: 0,
+            lastPlayedAt: 1_700_000_010_000
+        )
+
+        try queue.write { db in try record.insert(db) }
+
+        let fetched = try queue.read { db in
+            try PlaybackHistoryRecord.fetchOne(
+                db,
+                sql: "SELECT * FROM playback_history WHERE torrent_id = ?",
+                arguments: ["ca-nil"]
+            )
+        }
+        XCTAssertNil(fetched?.completedAt)
+    }
+
+    func testCompletedAtRoundTripsWhenSet() throws {
+        let record = PlaybackHistoryRecord(
+            torrentId: "ca-set",
+            fileIndex: 1,
+            resumeByteOffset: 9_500_000,
+            lastPlayedAt: 1_700_000_011_000,
+            completed: true,
+            completedAt: 1_700_000_012_345
+        )
+
+        try queue.write { db in try record.insert(db) }
+
+        let fetched = try queue.read { db in
+            try PlaybackHistoryRecord.fetchOne(
+                db,
+                sql: "SELECT * FROM playback_history WHERE torrent_id = ?",
+                arguments: ["ca-set"]
+            )
+        }
+        XCTAssertEqual(fetched?.completedAt, 1_700_000_012_345)
+        XCTAssertEqual(fetched?.completed, true)
+    }
+
+    func testCompletedAtUpdatesViaSave() throws {
+        var record = PlaybackHistoryRecord(
+            torrentId: "ca-update",
+            fileIndex: 0,
+            resumeByteOffset: 9_500_000,
+            lastPlayedAt: 1_700_000_013_000,
+            completed: true,
+            completedAt: 1_700_000_013_001
+        )
+        try queue.write { db in try record.insert(db) }
+
+        record.completedAt = 1_700_000_999_999 // most-recent-completion-wins
+        try queue.write { db in try record.save(db) }
+
+        let fetched = try queue.read { db in
+            try PlaybackHistoryRecord.fetchOne(
+                db,
+                sql: "SELECT * FROM playback_history WHERE torrent_id = ?",
+                arguments: ["ca-update"]
+            )
+        }
+        XCTAssertEqual(fetched?.completedAt, 1_700_000_999_999)
+    }
+
     // MARK: - Upsert (update existing row)
 
     func testUpsertUpdatesExistingRow() throws {

--- a/Packages/LibraryDomain/Package.swift
+++ b/Packages/LibraryDomain/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "LibraryDomain",
+    platforms: [
+        .macOS(.v26)
+    ],
+    products: [
+        .library(name: "LibraryDomain", targets: ["LibraryDomain"])
+    ],
+    dependencies: [
+        .package(path: "../EngineInterface")
+    ],
+    targets: [
+        .target(
+            name: "LibraryDomain",
+            dependencies: [
+                .product(name: "EngineInterface", package: "EngineInterface")
+            ],
+            path: "Sources/LibraryDomain"
+        ),
+        .testTarget(
+            name: "LibraryDomainTests",
+            dependencies: ["LibraryDomain"],
+            path: "Tests/LibraryDomainTests"
+        )
+    ]
+)

--- a/Packages/LibraryDomain/Sources/LibraryDomain/WatchStateMachine.swift
+++ b/Packages/LibraryDomain/Sources/LibraryDomain/WatchStateMachine.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Events that drive the `WatchStateMachine`. Mirrors the engine's write
+/// triggers (stream open, periodic progress, stream close, manual toggles).
+public enum WatchEvent: Equatable, Sendable {
+    case streamOpened(totalBytes: Int64)
+    case progress(bytes: Int64, totalBytes: Int64)
+    case streamClosed(finalBytes: Int64, totalBytes: Int64)
+    case manuallyMarkedWatched(at: Date)
+    case manuallyMarkedUnwatched
+}
+
+/// Pure-function state machine for watch-state transitions. Mirrors the
+/// engine's persistence path so the app can preview the result of a user
+/// action without round-tripping through the engine. Tests cover the full
+/// event × status matrix in `docs/design/watch-state-foundation.md`.
+///
+/// `now` is injected — never read from the system clock — so all transitions
+/// are deterministic. No I/O, no `DispatchQueue`, no randomness.
+public enum WatchStateMachine {
+
+    /// Apply `event` to `status`, producing the new status as of `now`.
+    public static func apply(_ event: WatchEvent,
+                             to status: WatchStatus,
+                             now: Date) -> WatchStatus {
+        switch (status, event) {
+
+        // MARK: streamOpened
+
+        case let (.unwatched, .streamOpened(total)):
+            return .inProgress(progressBytes: 0, totalBytes: total)
+
+        case (.inProgress, .streamOpened):
+            return status // idempotent — opening again from in-progress
+
+        case let (.watched(when), .streamOpened(total)):
+            return .reWatching(progressBytes: 0,
+                               totalBytes: total,
+                               previouslyCompletedAt: when)
+
+        case (.reWatching, .streamOpened):
+            return status // idempotent
+
+        // MARK: progress
+
+        case let (.unwatched, .progress(bytes, total)):
+            return .inProgress(progressBytes: bytes, totalBytes: total)
+
+        case let (.inProgress(p, _), .progress(bytes, total)):
+            return .inProgress(progressBytes: max(p, bytes), totalBytes: total)
+
+        case let (.watched(when), .progress(bytes, total)):
+            // Invariant: progress without an opened stream is unexpected.
+            // Defensive: treat as the start of a re-watch.
+            return .reWatching(progressBytes: bytes,
+                               totalBytes: total,
+                               previouslyCompletedAt: when)
+
+        case let (.reWatching(p, _, when), .progress(bytes, total)):
+            return .reWatching(progressBytes: max(p, bytes),
+                               totalBytes: total,
+                               previouslyCompletedAt: when)
+
+        // MARK: streamClosed
+
+        case let (.unwatched, .streamClosed(bytes, total)):
+            if bytes == 0 { return .unwatched }
+            if WatchThreshold.isComplete(progress: bytes, total: total) {
+                return .watched(completedAt: now)
+            }
+            return .inProgress(progressBytes: bytes, totalBytes: total)
+
+        case let (.inProgress(p, _), .streamClosed(bytes, total)):
+            if WatchThreshold.isComplete(progress: bytes, total: total) {
+                return .watched(completedAt: now)
+            }
+            return .inProgress(progressBytes: max(p, bytes), totalBytes: total)
+
+        case let (.watched(when), .streamClosed(bytes, _)):
+            // Closed without progress — preserve original watch.
+            if bytes == 0 { return .watched(completedAt: when) }
+            return .watched(completedAt: when) // defensive idempotence
+
+        case let (.reWatching(p, _, when), .streamClosed(bytes, total)):
+            if WatchThreshold.isComplete(progress: bytes, total: total) {
+                // Re-completion — `completed_at` updates per A26 most-recent-wins.
+                return .watched(completedAt: now)
+            }
+            return .reWatching(progressBytes: max(p, bytes),
+                               totalBytes: total,
+                               previouslyCompletedAt: when)
+
+        // MARK: manuallyMarkedWatched
+
+        case (.unwatched, .manuallyMarkedWatched(let now)),
+             (.inProgress, .manuallyMarkedWatched(let now)):
+            return .watched(completedAt: now)
+
+        case let (.watched(when), .manuallyMarkedWatched):
+            return .watched(completedAt: when) // idempotent — keeps original W
+
+        case (.reWatching, .manuallyMarkedWatched(let now)):
+            return .watched(completedAt: now) // re-stamp per design § Notes
+
+        // MARK: manuallyMarkedUnwatched
+
+        case (_, .manuallyMarkedUnwatched):
+            return .unwatched
+        }
+    }
+}

--- a/Packages/LibraryDomain/Sources/LibraryDomain/WatchStatus.swift
+++ b/Packages/LibraryDomain/Sources/LibraryDomain/WatchStatus.swift
@@ -1,0 +1,86 @@
+import Foundation
+import EngineInterface
+
+/// App-side projection of a file's watch state, derived from a
+/// `PlaybackHistoryDTO` row plus the file's `totalBytes`. See spec 05 rev 5,
+/// addendum A26, and `docs/design/watch-state-foundation.md`.
+public enum WatchStatus: Equatable, Sendable {
+    /// File has never been opened, or has been manually marked unwatched.
+    case unwatched
+    /// File is partway through; never previously completed.
+    case inProgress(progressBytes: Int64, totalBytes: Int64)
+    /// File was completed; not currently being re-watched.
+    /// `completedAt` reflects the most recent completion (most-recent-wins per A26).
+    case watched(completedAt: Date)
+    /// File was previously completed and is now being watched again.
+    /// `previouslyCompletedAt` is the row's `completed_at` snapshot at the
+    /// moment this status was derived. May be replaced by `now` if the
+    /// re-watch crosses the threshold again.
+    case reWatching(progressBytes: Int64,
+                    totalBytes: Int64,
+                    previouslyCompletedAt: Date)
+}
+
+public extension WatchStatus {
+
+    /// Project a row from the engine into a status for the UI.
+    /// `nil` row → `.unwatched`. Defensive fallbacks are documented per the
+    /// derivation matrix in `docs/design/watch-state-foundation.md`.
+    static func from(history: PlaybackHistoryDTO?, totalBytes: Int64) -> WatchStatus {
+        guard let dto = history else { return .unwatched }
+        return from(snapshot: PlaybackHistorySnapshotView(dto: dto), totalBytes: totalBytes)
+    }
+
+    /// Internal derivation entry point used by tests with a synthetic snapshot,
+    /// and by the `from(history:totalBytes:)` overload above.
+    static func from(snapshot: PlaybackHistorySnapshotView,
+                     totalBytes: Int64) -> WatchStatus {
+        let progress = snapshot.resumeByteOffset
+        switch (snapshot.completed, snapshot.completedAt, progress) {
+        case (false, nil, 0):
+            return .unwatched
+        case (false, nil, let p) where p > 0:
+            return .inProgress(progressBytes: p, totalBytes: totalBytes)
+        case (true, let when?, 0):
+            return .watched(completedAt: when)
+        case (true, let when?, let p) where p > 0:
+            return .reWatching(progressBytes: p,
+                               totalBytes: totalBytes,
+                               previouslyCompletedAt: when)
+        case (true, nil, _):
+            // Invariant violation: completed=true requires completedAt.
+            // Defensive: treat as freshly watched at epoch — caller should log.
+            return .watched(completedAt: Date(timeIntervalSince1970: 0))
+        case (false, _?, let p):
+            // Invariant violation: completed=false should clear completedAt.
+            // Defensive: ignore the stale timestamp and use byte-offset semantics.
+            return p > 0
+                ? .inProgress(progressBytes: p, totalBytes: totalBytes)
+                : .unwatched
+        default:
+            return .unwatched
+        }
+    }
+}
+
+/// View struct over the DTO that hides the NSNumber? layer. Lets the
+/// derivation function pattern-match on plain Swift types.
+public struct PlaybackHistorySnapshotView: Equatable, Sendable {
+    public let resumeByteOffset: Int64
+    public let completed: Bool
+    public let completedAt: Date?
+
+    public init(resumeByteOffset: Int64, completed: Bool, completedAt: Date?) {
+        self.resumeByteOffset = resumeByteOffset
+        self.completed = completed
+        self.completedAt = completedAt
+    }
+
+    public init(dto: PlaybackHistoryDTO) {
+        self.resumeByteOffset = dto.resumeByteOffset
+        self.completed = dto.completed
+        self.completedAt = dto.completedAt.map {
+            Date(timeIntervalSince1970: TimeInterval($0.int64Value) / 1000.0)
+        }
+    }
+}

--- a/Packages/LibraryDomain/Sources/LibraryDomain/WatchThreshold.swift
+++ b/Packages/LibraryDomain/Sources/LibraryDomain/WatchThreshold.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Single source for the "is this file complete?" rule. Both engine
+/// (`CacheManager` write path) and app (`WatchStatus` derivation) consume
+/// this helper to avoid drift.
+///
+/// The rule is `progress >= 0.95 * total` per spec 05 § Update rules. Stored
+/// as integer arithmetic to avoid double-precision drift at large file sizes.
+public enum WatchThreshold {
+    /// `true` when `progress` is at or beyond 95% of `total`.
+    /// `total <= 0` returns `false` — undefined files are never "complete."
+    public static func isComplete(progress: Int64, total: Int64) -> Bool {
+        guard total > 0 else { return false }
+        // Integer rearrangement of `progress >= 0.95 * total`:
+        //   progress * 100 >= total * 95
+        // Avoids floating-point drift on multi-GB files.
+        return progress.multipliedReportingOverflow(by: 100).0 >=
+               total.multipliedReportingOverflow(by: 95).0
+    }
+}

--- a/Packages/LibraryDomain/Tests/LibraryDomainTests/WatchStateMachineTests.swift
+++ b/Packages/LibraryDomain/Tests/LibraryDomainTests/WatchStateMachineTests.swift
@@ -1,0 +1,309 @@
+import XCTest
+@testable import LibraryDomain
+
+/// Covers every cell in the transition matrix in
+/// `docs/design/watch-state-foundation.md` § "Transition matrix".
+final class WatchStateMachineTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private let total: Int64 = 1_000_000_000
+    private let now = Date(timeIntervalSince1970: 1_700_000_500)
+    private let earlier = Date(timeIntervalSince1970: 1_700_000_100)
+    /// 95% of total; threshold per spec 05.
+    private var threshold: Int64 { total * 95 / 100 }
+
+    // MARK: - From .unwatched
+
+    func test_unwatched_streamOpened_isInProgressZero() {
+        let next = WatchStateMachine.apply(
+            .streamOpened(totalBytes: total),
+            to: .unwatched,
+            now: now
+        )
+        XCTAssertEqual(next, .inProgress(progressBytes: 0, totalBytes: total))
+    }
+
+    func test_unwatched_progress_isInProgressAtBytes() {
+        let next = WatchStateMachine.apply(
+            .progress(bytes: 100, totalBytes: total),
+            to: .unwatched,
+            now: now
+        )
+        XCTAssertEqual(next, .inProgress(progressBytes: 100, totalBytes: total))
+    }
+
+    func test_unwatched_streamClosed_zeroBytes_stays() {
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: 0, totalBytes: total),
+            to: .unwatched,
+            now: now
+        )
+        XCTAssertEqual(next, .unwatched)
+    }
+
+    func test_unwatched_streamClosed_belowThreshold_isInProgress() {
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: 100, totalBytes: total),
+            to: .unwatched,
+            now: now
+        )
+        XCTAssertEqual(next, .inProgress(progressBytes: 100, totalBytes: total))
+    }
+
+    func test_unwatched_streamClosed_atThreshold_isWatchedNow() {
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: threshold, totalBytes: total),
+            to: .unwatched,
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: now))
+    }
+
+    func test_unwatched_manuallyMarkedWatched_isWatchedAtMarkTime() {
+        let mark = Date(timeIntervalSince1970: 999)
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedWatched(at: mark),
+            to: .unwatched,
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: mark))
+    }
+
+    func test_unwatched_manuallyMarkedUnwatched_idempotent() {
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedUnwatched,
+            to: .unwatched,
+            now: now
+        )
+        XCTAssertEqual(next, .unwatched)
+    }
+
+    // MARK: - From .inProgress
+
+    func test_inProgress_streamOpened_idempotent() {
+        let start: WatchStatus = .inProgress(progressBytes: 250, totalBytes: total)
+        let next = WatchStateMachine.apply(
+            .streamOpened(totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, start)
+    }
+
+    func test_inProgress_progress_takesMaxBytes() {
+        let start: WatchStatus = .inProgress(progressBytes: 250, totalBytes: total)
+        let nextHigher = WatchStateMachine.apply(
+            .progress(bytes: 999, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(nextHigher, .inProgress(progressBytes: 999, totalBytes: total))
+
+        // A late progress event with stale bytes must NOT regress.
+        let nextStale = WatchStateMachine.apply(
+            .progress(bytes: 100, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(nextStale, start)
+    }
+
+    func test_inProgress_streamClosed_atThreshold_isWatchedNow() {
+        let start: WatchStatus = .inProgress(progressBytes: 250, totalBytes: total)
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: threshold, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: now))
+    }
+
+    func test_inProgress_streamClosed_belowThreshold_keepsProgressMax() {
+        let start: WatchStatus = .inProgress(progressBytes: 500, totalBytes: total)
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: 250, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .inProgress(progressBytes: 500, totalBytes: total))
+    }
+
+    func test_inProgress_manuallyMarkedWatched_isWatchedAtMarkTime() {
+        let mark = Date(timeIntervalSince1970: 999)
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedWatched(at: mark),
+            to: .inProgress(progressBytes: 100, totalBytes: total),
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: mark))
+    }
+
+    func test_inProgress_manuallyMarkedUnwatched_isUnwatched() {
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedUnwatched,
+            to: .inProgress(progressBytes: 100, totalBytes: total),
+            now: now
+        )
+        XCTAssertEqual(next, .unwatched)
+    }
+
+    // MARK: - From .watched
+
+    func test_watched_streamOpened_isReWatchingZeroPreservingPrevious() {
+        let start: WatchStatus = .watched(completedAt: earlier)
+        let next = WatchStateMachine.apply(
+            .streamOpened(totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .reWatching(progressBytes: 0,
+                                          totalBytes: total,
+                                          previouslyCompletedAt: earlier))
+    }
+
+    func test_watched_progress_defensivelyEntersReWatching() {
+        let start: WatchStatus = .watched(completedAt: earlier)
+        let next = WatchStateMachine.apply(
+            .progress(bytes: 100, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .reWatching(progressBytes: 100,
+                                          totalBytes: total,
+                                          previouslyCompletedAt: earlier))
+    }
+
+    func test_watched_streamClosed_zeroBytes_idempotent() {
+        let start: WatchStatus = .watched(completedAt: earlier)
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: 0, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, start)
+    }
+
+    func test_watched_manuallyMarkedWatched_keepsOriginalDate() {
+        let start: WatchStatus = .watched(completedAt: earlier)
+        let later = Date(timeIntervalSince1970: 999_999)
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedWatched(at: later),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: earlier),
+                       "manual mark on an already-watched row preserves original W")
+    }
+
+    func test_watched_manuallyMarkedUnwatched_isUnwatched() {
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedUnwatched,
+            to: .watched(completedAt: earlier),
+            now: now
+        )
+        XCTAssertEqual(next, .unwatched)
+    }
+
+    // MARK: - From .reWatching
+
+    func test_reWatching_streamOpened_idempotent() {
+        let start: WatchStatus = .reWatching(progressBytes: 250,
+                                              totalBytes: total,
+                                              previouslyCompletedAt: earlier)
+        let next = WatchStateMachine.apply(
+            .streamOpened(totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, start)
+    }
+
+    func test_reWatching_progress_takesMaxAndPreservesPrevious() {
+        let start: WatchStatus = .reWatching(progressBytes: 250,
+                                              totalBytes: total,
+                                              previouslyCompletedAt: earlier)
+        let next = WatchStateMachine.apply(
+            .progress(bytes: 999, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .reWatching(progressBytes: 999,
+                                          totalBytes: total,
+                                          previouslyCompletedAt: earlier))
+    }
+
+    func test_reWatching_streamClosed_atThreshold_replacesWWithNow() {
+        let start: WatchStatus = .reWatching(progressBytes: 250,
+                                              totalBytes: total,
+                                              previouslyCompletedAt: earlier)
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: threshold, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: now),
+                       "re-completion replaces the completedAt with now (A26 most-recent-wins)")
+    }
+
+    func test_reWatching_streamClosed_belowThreshold_persistsRewatch() {
+        let start: WatchStatus = .reWatching(progressBytes: 500,
+                                              totalBytes: total,
+                                              previouslyCompletedAt: earlier)
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: 250, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .reWatching(progressBytes: 500,
+                                          totalBytes: total,
+                                          previouslyCompletedAt: earlier))
+    }
+
+    func test_reWatching_manuallyMarkedWatched_replacesWWithMarkTime() {
+        let start: WatchStatus = .reWatching(progressBytes: 250,
+                                              totalBytes: total,
+                                              previouslyCompletedAt: earlier)
+        let mark = Date(timeIntervalSince1970: 999_999)
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedWatched(at: mark),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: mark),
+                       "mark-watched on re-watch re-stamps to the new mark time")
+    }
+
+    func test_reWatching_manuallyMarkedUnwatched_isUnwatched() {
+        let next = WatchStateMachine.apply(
+            .manuallyMarkedUnwatched,
+            to: .reWatching(progressBytes: 250,
+                            totalBytes: total,
+                            previouslyCompletedAt: earlier),
+            now: now
+        )
+        XCTAssertEqual(next, .unwatched)
+    }
+
+    // MARK: - Threshold edges
+
+    func test_thresholdEdge_oneByteShortStaysInProgress() {
+        let start: WatchStatus = .inProgress(progressBytes: 0, totalBytes: total)
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: threshold - 1, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .inProgress(progressBytes: threshold - 1, totalBytes: total))
+    }
+
+    func test_thresholdEdge_exactlyAtCompletes() {
+        let start: WatchStatus = .inProgress(progressBytes: 0, totalBytes: total)
+        let next = WatchStateMachine.apply(
+            .streamClosed(finalBytes: threshold, totalBytes: total),
+            to: start,
+            now: now
+        )
+        XCTAssertEqual(next, .watched(completedAt: now))
+    }
+}

--- a/Packages/LibraryDomain/Tests/LibraryDomainTests/WatchStatusDerivationTests.swift
+++ b/Packages/LibraryDomain/Tests/LibraryDomainTests/WatchStatusDerivationTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import EngineInterface
+@testable import LibraryDomain
+
+/// Covers every row in the derivation matrix in
+/// `docs/design/watch-state-foundation.md` § "Derivation matrix".
+final class WatchStatusDerivationTests: XCTestCase {
+
+    // MARK: - Test fixtures
+
+    private let total: Int64 = 1_000_000_000
+    private let watchedDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func makeView(completed: Bool, completedAt: Date?, resume: Int64) -> PlaybackHistorySnapshotView {
+        PlaybackHistorySnapshotView(
+            resumeByteOffset: resume,
+            completed: completed,
+            completedAt: completedAt
+        )
+    }
+
+    // MARK: - Matrix rows
+
+    func test_rowAbsent_isUnwatched() {
+        XCTAssertEqual(WatchStatus.from(history: nil, totalBytes: total), .unwatched)
+    }
+
+    func test_completedFalse_completedAtNil_resumeZero_isUnwatched() {
+        let view = makeView(completed: false, completedAt: nil, resume: 0)
+        XCTAssertEqual(WatchStatus.from(snapshot: view, totalBytes: total), .unwatched)
+    }
+
+    func test_completedFalse_completedAtNil_resumePositive_isInProgress() {
+        let view = makeView(completed: false, completedAt: nil, resume: 250_000_000)
+        XCTAssertEqual(
+            WatchStatus.from(snapshot: view, totalBytes: total),
+            .inProgress(progressBytes: 250_000_000, totalBytes: total)
+        )
+    }
+
+    func test_completedTrue_completedAtSet_resumeZero_isWatched() {
+        let view = makeView(completed: true, completedAt: watchedDate, resume: 0)
+        XCTAssertEqual(
+            WatchStatus.from(snapshot: view, totalBytes: total),
+            .watched(completedAt: watchedDate)
+        )
+    }
+
+    func test_completedTrue_completedAtSet_resumePositive_isReWatching() {
+        let view = makeView(completed: true, completedAt: watchedDate, resume: 100_000_000)
+        XCTAssertEqual(
+            WatchStatus.from(snapshot: view, totalBytes: total),
+            .reWatching(progressBytes: 100_000_000,
+                        totalBytes: total,
+                        previouslyCompletedAt: watchedDate)
+        )
+    }
+
+    // MARK: - Invariant violations
+
+    func test_completedTrue_completedAtNil_isWatchedFromEpoch() {
+        // Defensive fallback per the design doc — caller logs the violation.
+        let view = makeView(completed: true, completedAt: nil, resume: 50_000_000)
+        XCTAssertEqual(
+            WatchStatus.from(snapshot: view, totalBytes: total),
+            .watched(completedAt: Date(timeIntervalSince1970: 0))
+        )
+    }
+
+    func test_completedFalse_completedAtSet_resumeZero_isUnwatched() {
+        // Defensive: stale completedAt is ignored when completed=false.
+        let view = makeView(completed: false, completedAt: watchedDate, resume: 0)
+        XCTAssertEqual(WatchStatus.from(snapshot: view, totalBytes: total), .unwatched)
+    }
+
+    func test_completedFalse_completedAtSet_resumePositive_isInProgress() {
+        let view = makeView(completed: false, completedAt: watchedDate, resume: 250_000_000)
+        XCTAssertEqual(
+            WatchStatus.from(snapshot: view, totalBytes: total),
+            .inProgress(progressBytes: 250_000_000, totalBytes: total)
+        )
+    }
+
+    // MARK: - DTO bridge
+
+    func test_dtoBridge_completedAtRoundTrips() {
+        // Mirror what the engine writes: completedAt as unix-ms in NSNumber.
+        let dto = PlaybackHistoryDTO(
+            torrentID: "ph-bridge",
+            fileIndex: 0,
+            resumeByteOffset: 0,
+            lastPlayedAt: 0,
+            totalWatchedSeconds: 0,
+            completed: true,
+            completedAt: NSNumber(value: 1_700_000_000_000) // ms == 1_700_000_000 s
+        )
+        let status = WatchStatus.from(history: dto, totalBytes: total)
+        guard case .watched(let when) = status else {
+            return XCTFail("expected .watched, got \(status)")
+        }
+        XCTAssertEqual(when.timeIntervalSince1970, 1_700_000_000.0, accuracy: 0.001)
+    }
+}

--- a/Packages/LibraryDomain/Tests/LibraryDomainTests/WatchThresholdTests.swift
+++ b/Packages/LibraryDomain/Tests/LibraryDomainTests/WatchThresholdTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import LibraryDomain
+
+final class WatchThresholdTests: XCTestCase {
+
+    func testZeroTotalIsNeverComplete() {
+        XCTAssertFalse(WatchThreshold.isComplete(progress: 0, total: 0))
+        XCTAssertFalse(WatchThreshold.isComplete(progress: 1_000, total: 0))
+    }
+
+    func testNegativeTotalIsNeverComplete() {
+        XCTAssertFalse(WatchThreshold.isComplete(progress: 100, total: -10))
+    }
+
+    func testExactlyAtThresholdIsComplete() {
+        // 95 / 100 == 0.95
+        XCTAssertTrue(WatchThreshold.isComplete(progress: 95, total: 100))
+    }
+
+    func testJustBelowThresholdIsNotComplete() {
+        // 94 / 100 == 0.94 < 0.95
+        XCTAssertFalse(WatchThreshold.isComplete(progress: 94, total: 100))
+    }
+
+    func testWayBelowThreshold() {
+        XCTAssertFalse(WatchThreshold.isComplete(progress: 0, total: 1_000_000))
+        XCTAssertFalse(WatchThreshold.isComplete(progress: 1_000, total: 1_000_000))
+    }
+
+    func testFullyComplete() {
+        XCTAssertTrue(WatchThreshold.isComplete(progress: 1_000_000, total: 1_000_000))
+    }
+
+    func testLargeFileBoundary() {
+        // 4 GB file: 0.95 * 4_294_967_296 == 4_080_218_931.2.
+        // Integer formula `progress * 100 >= total * 95` is exact: smallest
+        // integer that passes is ceil(total * 95 / 100) = 4_080_218_932.
+        let total: Int64 = 4_294_967_296
+        let boundary: Int64 = (total * 95 + 99) / 100   // ceil division
+        XCTAssertTrue(WatchThreshold.isComplete(progress: boundary, total: total))
+        XCTAssertFalse(WatchThreshold.isComplete(progress: boundary - 1, total: total))
+    }
+}

--- a/Packages/XPCMapping/Sources/XPCMapping/DomainTypes.swift
+++ b/Packages/XPCMapping/Sources/XPCMapping/DomainTypes.swift
@@ -156,3 +156,37 @@ public enum DiskPressureLevel: String, Sendable, Hashable, CaseIterable {
     case warn
     case critical
 }
+
+// MARK: - PlaybackHistorySnapshot (A26)
+
+/// Engine-internal projection of a `playback_history` row. Crosses the XPC
+/// boundary as `PlaybackHistoryDTO`. See spec 05 rev 5 § Schema and addendum
+/// A26.
+public struct PlaybackHistorySnapshot: Sendable, Hashable {
+    public let torrentID: String
+    public let fileIndex: Int
+    public let resumeByteOffset: Int64
+    public let lastPlayedAtMillis: Int64
+    public let totalWatchedSeconds: Double
+    public let completed: Bool
+    /// Unix milliseconds of the most recent completion; `nil` if never completed.
+    public let completedAtMillis: Int64?
+
+    public init(
+        torrentID: String,
+        fileIndex: Int,
+        resumeByteOffset: Int64,
+        lastPlayedAtMillis: Int64,
+        totalWatchedSeconds: Double,
+        completed: Bool,
+        completedAtMillis: Int64?
+    ) {
+        self.torrentID = torrentID
+        self.fileIndex = fileIndex
+        self.resumeByteOffset = resumeByteOffset
+        self.lastPlayedAtMillis = lastPlayedAtMillis
+        self.totalWatchedSeconds = totalWatchedSeconds
+        self.completed = completed
+        self.completedAtMillis = completedAtMillis
+    }
+}

--- a/Packages/XPCMapping/Sources/XPCMapping/Mapping.swift
+++ b/Packages/XPCMapping/Sources/XPCMapping/Mapping.swift
@@ -207,6 +207,36 @@ extension DiskPressure {
     }
 }
 
+// MARK: - PlaybackHistorySnapshot ↔ PlaybackHistoryDTO (A26)
+
+extension PlaybackHistoryDTO {
+    public convenience init(from domain: PlaybackHistorySnapshot) {
+        self.init(
+            torrentID: domain.torrentID as NSString,
+            fileIndex: Int32(clamping: domain.fileIndex),
+            resumeByteOffset: domain.resumeByteOffset,
+            lastPlayedAt: domain.lastPlayedAtMillis,
+            totalWatchedSeconds: domain.totalWatchedSeconds,
+            completed: domain.completed,
+            completedAt: domain.completedAtMillis.map { NSNumber(value: $0) }
+        )
+    }
+}
+
+extension PlaybackHistorySnapshot {
+    public init(from dto: PlaybackHistoryDTO) {
+        self.init(
+            torrentID: dto.torrentID as String,
+            fileIndex: Int(dto.fileIndex),
+            resumeByteOffset: dto.resumeByteOffset,
+            lastPlayedAtMillis: dto.lastPlayedAt,
+            totalWatchedSeconds: dto.totalWatchedSeconds,
+            completed: dto.completed,
+            completedAtMillis: dto.completedAt?.int64Value
+        )
+    }
+}
+
 // MARK: - Helpers
 
 private extension Double {

--- a/Packages/XPCMapping/Tests/XPCMappingTests/MappingTests.swift
+++ b/Packages/XPCMapping/Tests/XPCMappingTests/MappingTests.swift
@@ -382,3 +382,50 @@ final class MappingTests: XCTestCase {
         XCTAssertEqual(dto1.availableRanges.first?.startByte, dto2.availableRanges.first?.startByte)
     }
 }
+
+// MARK: - PlaybackHistorySnapshot ↔ PlaybackHistoryDTO (A26)
+
+final class PlaybackHistoryMappingTests: XCTestCase {
+
+    func test_playbackHistory_roundTrip_completedAtSet() {
+        let domain = PlaybackHistorySnapshot(
+            torrentID: "ph-1",
+            fileIndex: 2,
+            resumeByteOffset: 9_500_000,
+            lastPlayedAtMillis: 1_700_000_010_000,
+            totalWatchedSeconds: 0,
+            completed: true,
+            completedAtMillis: 1_700_000_012_345
+        )
+        let reconstructed = PlaybackHistorySnapshot(from: PlaybackHistoryDTO(from: domain))
+        XCTAssertEqual(reconstructed, domain)
+    }
+
+    func test_playbackHistory_roundTrip_completedAtNil() {
+        let domain = PlaybackHistorySnapshot(
+            torrentID: "ph-2",
+            fileIndex: 0,
+            resumeByteOffset: 1024,
+            lastPlayedAtMillis: 1_700_000_011_000,
+            totalWatchedSeconds: 0,
+            completed: false,
+            completedAtMillis: nil
+        )
+        let reconstructed = PlaybackHistorySnapshot(from: PlaybackHistoryDTO(from: domain))
+        XCTAssertEqual(reconstructed, domain)
+    }
+
+    func test_playbackHistory_unwatched_roundTrip() {
+        let domain = PlaybackHistorySnapshot(
+            torrentID: "ph-3",
+            fileIndex: 5,
+            resumeByteOffset: 0,
+            lastPlayedAtMillis: 1_700_000_012_000,
+            totalWatchedSeconds: 0,
+            completed: false,
+            completedAtMillis: nil
+        )
+        let reconstructed = PlaybackHistorySnapshot(from: PlaybackHistoryDTO(from: domain))
+        XCTAssertEqual(reconstructed, domain)
+    }
+}


### PR DESCRIPTION
## Summary

Lands the engine + domain + XPC foundation that #35, #36, and #37 build on. No SwiftUI changes; UI wiring is the dependent tickets' job.

Spec/docs landed previously in #154 (rev 5 of spec 05, addendum A26, design doc, T-STORE-FAVOURITES task).

## What changes

**Schema (engine):**
- New V2 migration `v2_add_completed_at` adds `playback_history.completed_at INTEGER NULL`. Additive, idempotent, preserves existing rows.
- `PlaybackHistoryRecord.completedAt: Int64?` field added.

**CacheManager (engine write rules per spec 05 rev 5 + A26):**
- `recordPlayback` sets `completed_at = now` on every 0→1 completion and on subsequent re-completions during a re-watch (most-recent-wins). `completed`/`completed_at` are preserved across re-watches; only `markUnwatched` clears them.
- New `markWatched`/`markUnwatched` write helpers with the canonical field shape from the design doc; `markUnwatched` preserves `last_played_at` so library ordering doesn't jump.
- `nowMillis` injection on every helper for deterministic tests.

**XPC contract additions (versioned per A1):**
- New `PlaybackHistoryDTO` (NSSecureCoding, `schemaVersion=1`).
- New methods `EngineXPC.listPlaybackHistory(_:)` and `EngineXPC.setWatchedState(torrentID:fileIndex:watched:reply:)`.
- New event `EngineEvents.playbackHistoryChanged(_:)` emitted exactly once per write — RealEngineBackend + FakeEngineBackend parity.
- `XPCInterfaceFactory` registers allowed classes for both new method and event.
- `EngineClient` async wrappers for both new methods.
- `EngineEventHandler` exposes `playbackHistoryChangedSubject`.

**LibraryDomain (new SPM package, app-side):**
- `WatchStatus` enum (`.unwatched`, `.inProgress`, `.watched`, `.reWatching`).
- `WatchStatus.from(history:totalBytes:)` derivation covering every row in the design doc's matrix incl. defensive invariant-violation fallbacks.
- `WatchStateMachine.apply(_:to:now:)` pure function with injected `now: Date` — no clocks, no I/O, no DispatchQueue (mirrors planner / A3).
- `WatchThreshold.isComplete(progress:total:)` — single source for the 0.95 rule, used by both engine and app.

**Mapping:**
- `PlaybackHistorySnapshot` domain type + bidirectional `XPCMapping` between snapshot and DTO.

## Test plan

All green locally:
- EngineStore: V2 migration (clean / idempotent / V1→V2 row preservation) + `completedAt` round-trip × 3.
- EngineInterface: `PlaybackHistoryDTOTests` × 3, factory rows for new method/event, `XPCPlaybackHistoryTests` × 3 covering the listPlaybackHistory / setWatchedState / playbackHistoryChanged trio in-process.
- XPCMapping: `PlaybackHistoryMappingTests` × 3.
- LibraryDomain: 7 derivation tests, 22 state-machine transitions, 7 threshold cases (incl. 4 GB boundary).
- EngineService self-test: 7 new CacheManager cases (10–16) covering completed_at write semantics, mark-watched insert/re-stamp, mark-unwatched clear-with-preserved-last_played_at, and absent-row no-op. All 16 cases pass under `--cache-manager-self-test`.
- CI matrix updated to include `LibraryDomain`.
- Both Xcode schemes (`ButterBar`, `EngineService`) build clean.

## Out of scope (deferred to dependent tickets)

- Library UI changes (continue-watching row, watched badge, context menu, heart toggle) — that's #35/#36/#37.
- `favourites` table — independent engine task `T-STORE-FAVOURITES` in `TASKS.md` Phase 8.
- Snapshot tests — none in this PR.

## References

- Design: [`docs/design/watch-state-foundation.md`](https://github.com/anonymort/butter-bar/blob/main/docs/design/watch-state-foundation.md)
- Spec: spec 05 rev 5; addendum A26.
- Roadmap: [`docs/v1-roadmap.md § Phase 1`](https://github.com/anonymort/butter-bar/blob/main/docs/v1-roadmap.md).

Closes #34
Refs #5, #35, #36, #37