### PR TITLE
engine: T-STORE-FAVOURITES — favourites table migration

### DIFF
--- a/.claude/tasks/TASKS.md
+++ b/.claude/tasks/TASKS.md
@@ -380,7 +380,7 @@ Benchmark: measure seek-to-first-frame time across the four trace fixtures. Reco
 
 Engine seams discovered during product-surface execution (per `docs/v1-roadmap.md § Missing engine seams`). Each seam is small, additive, and unblocks one or more product-surface issues.
 
-### T-STORE-FAVOURITES `[sonnet]` · TODO
+### T-STORE-FAVOURITES `[sonnet]` · DONE — `Packages/EngineStore` adds `V2FavouritesMigration` (named `v2_add_favourites`) creating the additive `favourites` table; `FavouriteRecord` value type with Codable/FetchableRecord/PersistableRecord conformances. 7 new tests: 4 covering the record (insert/fetch round-trip, save-replaces-on-PK-conflict, delete, table-exists) plus 3 covering migration ordering (idempotent, independent of `v2_add_completed_at`, fresh DB applies all three). Total EngineStore tests: 27. No XPC / DTO surface added — that's #36's scope.
 Add a GRDB additive migration for the `favourites` table per spec 07 § 4 (Watch state and local library). Schema:
 
 ```sql

--- a/Packages/EngineStore/Sources/EngineStore/EngineDatabase.swift
+++ b/Packages/EngineStore/Sources/EngineStore/EngineDatabase.swift
@@ -34,6 +34,9 @@ public enum EngineDatabase {
         migrator.registerMigration(V2Migration.identifier) { db in
             try V2Migration.perform(db)
         }
+        migrator.registerMigration(V2FavouritesMigration.identifier) { db in
+            try V2FavouritesMigration.perform(db)
+        }
         try migrator.migrate(queue)
     }
 }

--- a/Packages/EngineStore/Sources/EngineStore/FavouriteRecord.swift
+++ b/Packages/EngineStore/Sources/EngineStore/FavouriteRecord.swift
@@ -1,0 +1,31 @@
+import GRDB
+
+/// A row in the `favourites` table.
+///
+/// Mirrors `PinnedFileRecord` shape: per-file grain `(torrent_id, file_index)`,
+/// with a single `favourited_at` unix-millisecond timestamp. Title-level
+/// favouriting is deferred — see #36 § Out of scope.
+public struct FavouriteRecord: Codable, FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "favourites"
+
+    enum CodingKeys: String, CodingKey {
+        case torrentId = "torrent_id"
+        case fileIndex = "file_index"
+        case favouritedAt = "favourited_at"
+    }
+
+    /// Torrent info-hash or stable identifier, as assigned by libtorrent.
+    public var torrentId: String
+
+    /// Zero-based index of the file within the torrent's file list.
+    public var fileIndex: Int
+
+    /// Unix milliseconds when the file was favourited.
+    public var favouritedAt: Int64
+
+    public init(torrentId: String, fileIndex: Int, favouritedAt: Int64) {
+        self.torrentId = torrentId
+        self.fileIndex = fileIndex
+        self.favouritedAt = favouritedAt
+    }
+}

--- a/Packages/EngineStore/Sources/EngineStore/V2FavouritesMigration.swift
+++ b/Packages/EngineStore/Sources/EngineStore/V2FavouritesMigration.swift
@@ -1,0 +1,23 @@
+import GRDB
+
+/// Adds the `favourites` table for Epic #5 #36. See spec 07 § 4 (Watch state
+/// and local library — favourites required feature) and `TASKS.md` Phase 8
+/// `T-STORE-FAVOURITES`.
+///
+/// Independent of `v2_add_completed_at` (A26) — both are additive,
+/// named GRDB migrations and apply in registration order. Either can land
+/// first.
+enum V2FavouritesMigration {
+    static let identifier = "v2_add_favourites"
+
+    static func perform(_ db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE favourites (
+                torrent_id TEXT NOT NULL,
+                file_index INTEGER NOT NULL,
+                favourited_at INTEGER NOT NULL,
+                PRIMARY KEY (torrent_id, file_index)
+            )
+            """)
+    }
+}

--- a/Packages/EngineStore/Tests/EngineStoreTests/FavouriteRecordTests.swift
+++ b/Packages/EngineStore/Tests/EngineStoreTests/FavouriteRecordTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+import GRDB
+@testable import EngineStore
+
+final class FavouriteRecordTests: XCTestCase {
+
+    private var queue: DatabaseQueue!
+
+    override func setUpWithError() throws {
+        queue = try EngineDatabase.openInMemory()
+    }
+
+    func testRoundTripInsertFetch() throws {
+        let record = FavouriteRecord(
+            torrentId: "fav-1",
+            fileIndex: 3,
+            favouritedAt: 1_700_000_111_000
+        )
+        try queue.write { db in try record.insert(db) }
+
+        let fetched = try queue.read { db in
+            try FavouriteRecord.fetchOne(
+                db,
+                sql: "SELECT * FROM favourites WHERE torrent_id = ? AND file_index = ?",
+                arguments: ["fav-1", 3]
+            )
+        }
+
+        XCTAssertEqual(fetched?.torrentId, "fav-1")
+        XCTAssertEqual(fetched?.fileIndex, 3)
+        XCTAssertEqual(fetched?.favouritedAt, 1_700_000_111_000)
+    }
+
+    func testPrimaryKeyConflictReplacesRow() throws {
+        // GRDB's default PersistableRecord.save uses INSERT OR ABORT for new
+        // rows. For an upsert pattern callers must call .save() which falls
+        // back to UPDATE if INSERT throws on PK conflict. Verify that
+        // saving an updated row replaces the timestamp without throwing.
+        let r1 = FavouriteRecord(torrentId: "fav-2", fileIndex: 0,
+                                 favouritedAt: 1_700_000_001_000)
+        try queue.write { db in try r1.insert(db) }
+
+        let r2 = FavouriteRecord(torrentId: "fav-2", fileIndex: 0,
+                                 favouritedAt: 1_700_000_999_000)
+        try queue.write { db in try r2.save(db) }
+
+        let fetched = try queue.read { db in
+            try FavouriteRecord.fetchOne(
+                db,
+                sql: "SELECT * FROM favourites WHERE torrent_id = ? AND file_index = ?",
+                arguments: ["fav-2", 0]
+            )
+        }
+        XCTAssertEqual(fetched?.favouritedAt, 1_700_000_999_000)
+    }
+
+    func testDeleteRemovesRow() throws {
+        let record = FavouriteRecord(torrentId: "fav-3", fileIndex: 0,
+                                     favouritedAt: 1_700_000_002_000)
+        try queue.write { db in try record.insert(db) }
+
+        try queue.write { db in
+            _ = try FavouriteRecord
+                .filter(Column("torrent_id") == "fav-3" && Column("file_index") == 0)
+                .deleteAll(db)
+        }
+
+        let fetched = try queue.read { db in
+            try FavouriteRecord.fetchOne(
+                db,
+                sql: "SELECT * FROM favourites WHERE torrent_id = ? AND file_index = ?",
+                arguments: ["fav-3", 0]
+            )
+        }
+        XCTAssertNil(fetched)
+    }
+
+    func testTableExistsAfterMigration() throws {
+        try queue.read { db in
+            let tables = try String.fetchAll(
+                db,
+                sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'favourites'"
+            )
+            XCTAssertEqual(tables, ["favourites"])
+        }
+    }
+}
+
+// MARK: - Migration ordering / idempotency
+
+final class V2FavouritesMigrationTests: XCTestCase {
+
+    func testFavouritesMigrationIdempotent() throws {
+        let queue = try DatabaseQueue()
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration(V1Migration.identifier) { db in
+            try V1Migration.perform(db)
+        }
+        migrator.registerMigration(V2FavouritesMigration.identifier) { db in
+            try V2FavouritesMigration.perform(db)
+        }
+        try migrator.migrate(queue)
+        try migrator.migrate(queue) // re-run; must be no-op
+
+        try queue.read { db in
+            let count = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM grdb_migrations WHERE identifier = ?",
+                arguments: [V2FavouritesMigration.identifier]
+            )
+            XCTAssertEqual(count, 1, "favourites migration recorded more than once")
+        }
+    }
+
+    func testFavouritesMigrationIndependentOfCompletedAt() throws {
+        // Apply only V1 + favourites (skip v2_add_completed_at) and verify
+        // both succeed. This proves the two named migrations are independent.
+        let queue = try DatabaseQueue()
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration(V1Migration.identifier) { db in
+            try V1Migration.perform(db)
+        }
+        migrator.registerMigration(V2FavouritesMigration.identifier) { db in
+            try V2FavouritesMigration.perform(db)
+        }
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let tables = try String.fetchAll(
+                db,
+                sql: "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+            )
+            XCTAssertTrue(tables.contains("favourites"))
+            XCTAssertTrue(tables.contains("playback_history"))
+            // Verify completed_at column is NOT present (v2_add_completed_at skipped).
+            let columns = try Row.fetchAll(
+                db,
+                sql: "PRAGMA table_info(playback_history)"
+            ).compactMap { $0["name"] as String? }
+            XCTAssertFalse(columns.contains("completed_at"),
+                           "completed_at must not exist when only favourites migration is applied")
+        }
+    }
+
+    func testFreshDatabaseGetsAllMigrations() throws {
+        // EngineDatabase.openInMemory registers all three; verify they all apply.
+        let queue = try EngineDatabase.openInMemory()
+        try queue.read { db in
+            let recorded = try String.fetchAll(
+                db,
+                sql: "SELECT identifier FROM grdb_migrations ORDER BY identifier"
+            )
+            XCTAssertEqual(recorded, ["v1", "v2_add_completed_at", "v2_add_favourites"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Engine task `T-STORE-FAVOURITES` (TASKS.md Phase 8). Adds the `favourites` GRDB migration + `FavouriteRecord` value type. Unblocks #36. Independent of #34 — both V2 migrations are named and apply in either order.

## What changes

- `Packages/EngineStore/Sources/EngineStore/V2FavouritesMigration.swift` — new migration `v2_add_favourites`.
- `Packages/EngineStore/Sources/EngineStore/FavouriteRecord.swift` — new value type, mirrors `PinnedFileRecord` shape.
- `EngineDatabase.migrate(_:)` registers the new migration.
- `TASKS.md` Phase 8: T-STORE-FAVOURITES marked DONE.

## Test plan

7 new tests in `Packages/EngineStore` (27 total green):
- `FavouriteRecordTests` × 4: insert/fetch round-trip, save-replaces-on-PK-conflict, delete, table-exists.
- `V2FavouritesMigrationTests` × 3: idempotent, independent of `v2_add_completed_at`, fresh DB applies all three named migrations.

```
swift test --package-path Packages/EngineStore
# Executed 27 tests, with 0 failures
```

## Out of scope

- XPC contract additions (FavouriteDTO, listFavourites, setFavourite, favouritesChanged) — that's #36.
- App / UI surface — also #36.

Refs #5, #36