### PR TITLE
feat(subtitles): SubtitleDomain foundation (epic #4 phase 2, #27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           swift test --package-path Packages/XPCMapping
           swift test --package-path Packages/EngineStore
           swift test --package-path Packages/LibraryDomain
+          swift test --package-path Packages/SubtitleDomain
 
       - name: Snapshot tests (advisory — pixel drift on CI vs local)
         # CI runners don't have the owner's personal signing certificate for

--- a/Packages/SubtitleDomain/Package.swift
+++ b/Packages/SubtitleDomain/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "SubtitleDomain",
+    platforms: [
+        .macOS(.v26)
+    ],
+    products: [
+        .library(name: "SubtitleDomain", targets: ["SubtitleDomain"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "SubtitleDomain",
+            dependencies: [],
+            path: "Sources/SubtitleDomain"
+        ),
+        .testTarget(
+            name: "SubtitleDomainTests",
+            dependencies: ["SubtitleDomain"],
+            path: "Tests/SubtitleDomainTests"
+        )
+    ]
+)

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/LanguagePreferenceResolver.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/LanguagePreferenceResolver.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Picks a track from a list given a BCP-47 preference string. Pure
+/// function — no clocks, no I/O, no globals. See
+/// `docs/design/subtitle-foundation.md` § D8 and § Resolution matrix.
+///
+/// The resolver **partitions internally** by source type (embedded vs
+/// sidecar) and always tries embedded first, regardless of caller input
+/// order. Callers pass the tracks they have; they do not need to sort.
+public enum LanguagePreferenceResolver {
+
+    public static func pick(from tracks: [SubtitleTrack],
+                            preferred: String?) -> SubtitleTrack? {
+        guard let preferred else { return nil }
+        if preferred.caseInsensitiveCompare("off") == .orderedSame {
+            return nil
+        }
+
+        var embedded: [SubtitleTrack] = []
+        var sidecars: [SubtitleTrack] = []
+        for track in tracks {
+            switch track.source {
+            case .embedded:
+                embedded.append(track)
+            case .sidecar:
+                sidecars.append(track)
+            }
+        }
+
+        if let hit = firstMatch(in: embedded, preferred: preferred) {
+            return hit
+        }
+        return firstMatch(in: sidecars, preferred: preferred)
+    }
+
+    // MARK: - Internals
+
+    private static func firstMatch(in tracks: [SubtitleTrack],
+                                   preferred: String) -> SubtitleTrack? {
+        let prefPrimary = primarySubtag(of: preferred)
+        return tracks.first { track in
+            guard let lang = track.language else { return false }
+            return primarySubtag(of: lang).caseInsensitiveCompare(prefPrimary) == .orderedSame
+        }
+    }
+
+    /// Returns the primary (first) subtag of a BCP-47 tag, preserving the
+    /// caller's casing. `"en-US"` → `"en"`, `"pt-BR"` → `"pt"`,
+    /// `"zh-Hans"` → `"zh"`. Comparisons are done case-insensitively at
+    /// the call site.
+    internal static func primarySubtag(of tag: String) -> String {
+        if let dash = tag.firstIndex(of: "-") {
+            return String(tag[..<dash])
+        }
+        return tag
+    }
+}

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/SRTParser.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/SRTParser.swift
@@ -1,0 +1,158 @@
+import CoreMedia
+import Foundation
+
+/// Parses an SRT string into `[SubtitleCue]`. Pure function — no I/O, no
+/// clocks, no globals. See `docs/design/subtitle-foundation.md` § Type
+/// sketch for the contract.
+///
+/// Recoverable syntax slips (missing index, blank trailing lines, stray
+/// whitespace) are absorbed. Unrecoverable shape (no valid cues at all,
+/// or a malformed timecode within a cue block) surfaces as `.decoding`.
+public enum SRTParser {
+
+    public static func parse(_ text: String) -> Result<[SubtitleCue], SubtitleLoadError> {
+        let normalized = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+
+        // Split on one-or-more blank lines. Using a regex-free approach:
+        // iterate the blocks by collapsing runs of blank lines.
+        let blocks = splitBlocks(normalized)
+
+        if blocks.isEmpty {
+            return .success([])
+        }
+
+        var cues: [SubtitleCue] = []
+        for (ordinal, block) in blocks.enumerated() {
+            let lines = block.components(separatedBy: "\n").filter { !$0.isEmpty }
+            guard !lines.isEmpty else { continue }
+
+            guard let headerIdx = indexOfTimecodeLine(in: lines) else {
+                return .failure(.decoding(reason: "Block \(ordinal + 1) has no timecode line (no '-->' marker)."))
+            }
+
+            guard let (start, end) = parseTimecodeLine(lines[headerIdx]) else {
+                return .failure(.decoding(reason: "Block \(ordinal + 1) has an invalid timecode: \(lines[headerIdx])"))
+            }
+
+            // Index line is optional. If the timecode is on line 1 (not 0),
+            // line 0 is treated as the index if it's a pure integer.
+            let index: Int
+            if headerIdx >= 1,
+               let parsed = Int(lines[0].trimmingCharacters(in: .whitespaces)) {
+                index = parsed
+            } else {
+                index = ordinal + 1
+            }
+
+            let textLines = headerIdx + 1 < lines.count
+                ? Array(lines[(headerIdx + 1)...])
+                : []
+            let rawText = textLines.joined(separator: "\n")
+            let cleanText = Self.cleanupText(rawText)
+
+            cues.append(SubtitleCue(
+                index: index,
+                startTime: start,
+                endTime: end,
+                text: cleanText
+            ))
+        }
+
+        return .success(cues)
+    }
+
+    // MARK: - Internals (visible for tests)
+
+    internal static func splitBlocks(_ normalized: String) -> [String] {
+        var blocks: [String] = []
+        var current: [String] = []
+        for line in normalized.components(separatedBy: "\n") {
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                if !current.isEmpty {
+                    blocks.append(current.joined(separator: "\n"))
+                    current.removeAll(keepingCapacity: true)
+                }
+            } else {
+                current.append(line)
+            }
+        }
+        if !current.isEmpty {
+            blocks.append(current.joined(separator: "\n"))
+        }
+        return blocks
+    }
+
+    internal static func indexOfTimecodeLine(in lines: [String]) -> Int? {
+        for (i, line) in lines.enumerated() where line.contains("-->") {
+            return i
+        }
+        return nil
+    }
+
+    /// Parses a single timecode line like "HH:MM:SS,mmm --> HH:MM:SS,mmm".
+    /// Accepts `.` as an alternative millisecond separator (seen in some
+    /// wild-caught SRT files). Returns `nil` on any malformation.
+    internal static func parseTimecodeLine(_ line: String) -> (CMTime, CMTime)? {
+        let parts = line.components(separatedBy: "-->")
+        guard parts.count == 2 else { return nil }
+        let leftRaw = parts[0].trimmingCharacters(in: .whitespaces)
+        // Some files append cue-position hints after the end timecode
+        // (e.g. "X1:... Y1:..."). Strip anything after the first whitespace.
+        let rightRaw = parts[1]
+            .trimmingCharacters(in: .whitespaces)
+            .components(separatedBy: .whitespaces)
+            .first ?? ""
+        guard let start = parseTimecode(leftRaw),
+              let end = parseTimecode(rightRaw) else {
+            return nil
+        }
+        return (start, end)
+    }
+
+    internal static func parseTimecode(_ s: String) -> CMTime? {
+        // Normalize `,` to `.` for the milliseconds separator.
+        let normalized = s.replacingOccurrences(of: ",", with: ".")
+        let colonParts = normalized.components(separatedBy: ":")
+        guard colonParts.count == 3 else { return nil }
+        guard let h = Int(colonParts[0]),
+              let m = Int(colonParts[1]) else { return nil }
+        let secParts = colonParts[2].components(separatedBy: ".")
+        guard secParts.count == 2 else { return nil }
+        guard let sec = Int(secParts[0]),
+              let ms = Int(secParts[1]),
+              h >= 0, m >= 0, m < 60,
+              sec >= 0, sec < 60,
+              ms >= 0, ms < 1000 else { return nil }
+        let totalMs = Int64(h) * 3_600_000
+                    + Int64(m) * 60_000
+                    + Int64(sec) * 1_000
+                    + Int64(ms)
+        return CMTime(value: totalMs, timescale: 1_000)
+    }
+
+    /// Light tag stripping (`<i>`, `<b>`, `<u>`, case-insensitive) and
+    /// entity decoding. Not a full HTML parser — SRT in the wild uses only
+    /// a small vocabulary of presentational tags.
+    internal static func cleanupText(_ s: String) -> String {
+        let tagPatterns: [String] = [
+            "<i>", "</i>", "<I>", "</I>",
+            "<b>", "</b>", "<B>", "</B>",
+            "<u>", "</u>", "<U>", "</U>"
+        ]
+        var result = s
+        for tag in tagPatterns {
+            result = result.replacingOccurrences(of: tag, with: "")
+        }
+        // Entity decoding. Order matters: `&amp;` last so a literal
+        // `&amp;lt;` doesn't double-decode to `<`.
+        result = result
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&amp;", with: "&")
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleCue.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleCue.swift
@@ -1,0 +1,23 @@
+import CoreMedia
+import Foundation
+
+/// A single timed subtitle cue. Immutable; parsed once at ingestion.
+/// See `docs/design/subtitle-foundation.md` § Type sketch.
+public struct SubtitleCue: Equatable, Sendable {
+    /// 1-based index per SRT spec. Used only for diagnostics — do not rely
+    /// on this for ordering or lookup.
+    public let index: Int
+    public let startTime: CMTime
+    public let endTime: CMTime
+    /// Plain text. Light tag stripping (`<i>`, `<b>`, `<u>`) and entity
+    /// decoding (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`) are applied
+    /// by the parser.
+    public let text: String
+
+    public init(index: Int, startTime: CMTime, endTime: CMTime, text: String) {
+        self.index = index
+        self.startTime = startTime
+        self.endTime = endTime
+        self.text = text
+    }
+}

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleFormat.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleFormat.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Subtitle container format. Used for diagnostics and ingestion branching.
+///
+/// v1 scope (per design doc § D2):
+/// - Sidecar: `.srt` only. Other sidecar formats surface as
+///   `SubtitleLoadError.unsupportedFormat`.
+/// - Embedded: `.webVTT` / `.movText` / `.closedCaption` are exposed by
+///   AVKit's `.legible` selection group; we do not distinguish them in
+///   the UI.
+public enum SubtitleFormat: String, Equatable, Sendable, CaseIterable {
+    case srt
+    case webVTT
+    case movText
+    case closedCaption
+}

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleLoadError.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleLoadError.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Surfaced via the fallback banner (#32) when ingestion or activation
+/// fails. Each case carries a short reason string suitable for diagnostic
+/// logging — user-facing copy lives in `SubtitleErrorBanner` (#32) and
+/// follows the voice rules in `06-brand.md` § Voice.
+public enum SubtitleLoadError: Error, Equatable, Sendable {
+    /// File couldn't be read (missing, permissions, non-file URL).
+    case fileUnavailable(reason: String)
+    /// Bytes couldn't be decoded to text, or the parser couldn't recover
+    /// any valid cues.
+    case decoding(reason: String)
+    /// File extension or container format is not supported in v1.
+    case unsupportedFormat(reason: String)
+    /// AVKit embedded track activation failed at runtime.
+    case systemTrackFailed(reason: String)
+}

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleSource.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleSource.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Where a subtitle track comes from. Cues live in the `.sidecar` payload
+/// because they're inseparable from sidecar tracks and absent from
+/// embedded ones — see `docs/design/subtitle-foundation.md` § D3.
+public enum SubtitleSource: Equatable, Sendable {
+    /// AVKit-surfaced legible track. `identifier` is an opaque handle the
+    /// app layer maps back to `AVMediaSelectionOption` at selection time.
+    case embedded(identifier: String)
+    /// User-provided sidecar file, parsed into cues at ingestion.
+    case sidecar(url: URL, format: SubtitleFormat, cues: [SubtitleCue])
+}

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleTextDecoder.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleTextDecoder.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Decodes subtitle file bytes to a `String`. Tries UTF-8 first (with
+/// and without BOM), then Windows-1252, then ISO-8859-1. Binary data
+/// (failing the text-likelihood heuristic) surfaces as `.decoding`.
+///
+/// Rationale per design doc § D2: SRT files in the wild arrive in a
+/// handful of encodings; this fallback chain matches what VLC and mpv do.
+/// Windows-1252 is tried before ISO-8859-1 because legacy Windows tooling
+/// often tags files as Latin-1 when they actually contain CP-1252
+/// smart-quote bytes.
+public enum SubtitleTextDecoder {
+
+    public static func decode(_ data: Data) -> Result<String, SubtitleLoadError> {
+        // UTF-8 BOM: strip and decode.
+        if hasUTF8BOM(data) {
+            let stripped = data.dropFirst(3)
+            if let s = String(data: stripped, encoding: .utf8) {
+                return .success(s)
+            }
+        }
+        // Plain UTF-8.
+        if let s = String(data: data, encoding: .utf8) {
+            return .success(s)
+        }
+        // UTF-8 failed. Reject obvious binary before trying 8-bit encodings,
+        // because `.isoLatin1` decodes *any* byte sequence and would happily
+        // turn a JPEG into a nonsense string.
+        guard isLikelyText(data) else {
+            return .failure(.decoding(reason: "File does not look like a text document."))
+        }
+        if let s = String(data: data, encoding: .windowsCP1252) {
+            return .success(s)
+        }
+        if let s = String(data: data, encoding: .isoLatin1) {
+            return .success(s)
+        }
+        return .failure(.decoding(reason: "File is not valid UTF-8, Windows-1252, or ISO-8859-1 text."))
+    }
+
+    /// Heuristic: data is "likely text" if NUL bytes and non-whitespace
+    /// control bytes are each below 5% of the total. Conservative; allows
+    /// all reasonable SRT files through while rejecting obvious binary.
+    internal static func isLikelyText(_ data: Data) -> Bool {
+        guard !data.isEmpty else { return true }
+        var nulCount = 0
+        var controlCount = 0
+        for byte in data {
+            if byte == 0 {
+                nulCount += 1
+            } else if byte < 0x09 || (byte > 0x0D && byte < 0x20) {
+                controlCount += 1
+            }
+        }
+        return nulCount * 20 < data.count && controlCount * 20 < data.count
+    }
+
+    internal static func hasUTF8BOM(_ data: Data) -> Bool {
+        guard data.count >= 3 else { return false }
+        return data[data.startIndex] == 0xEF
+            && data[data.index(after: data.startIndex)] == 0xBB
+            && data[data.index(data.startIndex, offsetBy: 2)] == 0xBF
+    }
+}

--- a/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleTrack.swift
+++ b/Packages/SubtitleDomain/Sources/SubtitleDomain/SubtitleTrack.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Unified subtitle track — either an AVKit embedded track or a parsed
+/// sidecar. UI (`SubtitleSelectionMenu`, #29) and the language resolver
+/// (`LanguagePreferenceResolver`) range over `[SubtitleTrack]` uniformly.
+public struct SubtitleTrack: Equatable, Identifiable, Sendable {
+    /// Stable within a playback session — scope is "per stream open",
+    /// not persistent across app launches.
+    public let id: String
+    public let source: SubtitleSource
+    /// BCP-47 tag (e.g. `"en"`, `"pt-BR"`, `"zh-Hans"`). `nil` when the
+    /// track carries no language metadata.
+    public let language: String?
+    /// Human-readable label for the UI. The ingestor and the AVKit
+    /// mapping pick the right shape per source.
+    public let label: String
+
+    public init(id: String,
+                source: SubtitleSource,
+                language: String?,
+                label: String) {
+        self.id = id
+        self.source = source
+        self.language = language
+        self.label = label
+    }
+}

--- a/Packages/SubtitleDomain/Tests/SubtitleDomainTests/LanguagePreferenceResolverTests.swift
+++ b/Packages/SubtitleDomain/Tests/SubtitleDomainTests/LanguagePreferenceResolverTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import SubtitleDomain
+
+/// Covers every row of the resolution matrix in
+/// `docs/design/subtitle-foundation.md` § Resolution matrix.
+final class LanguagePreferenceResolverTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func embedded(_ id: String, _ lang: String?) -> SubtitleTrack {
+        SubtitleTrack(
+            id: id,
+            source: .embedded(identifier: id),
+            language: lang,
+            label: "Embedded \(id)"
+        )
+    }
+
+    private func sidecar(_ id: String, _ lang: String?) -> SubtitleTrack {
+        SubtitleTrack(
+            id: id,
+            source: .sidecar(url: URL(fileURLWithPath: "/tmp/\(id).srt"),
+                             format: .srt,
+                             cues: []),
+            language: lang,
+            label: "Sidecar \(id)"
+        )
+    }
+
+    // MARK: - Matrix rows
+
+    func test_preferredNil_returnsNil() {
+        let tracks = [embedded("e1", "en"), sidecar("s1", "en")]
+        XCTAssertNil(LanguagePreferenceResolver.pick(from: tracks, preferred: nil))
+    }
+
+    func test_preferredOff_returnsNil_evenWithMatchingTracks() {
+        let tracks = [embedded("e1", "en")]
+        XCTAssertNil(LanguagePreferenceResolver.pick(from: tracks, preferred: "off"))
+    }
+
+    func test_preferredOff_isCaseInsensitive() {
+        let tracks = [embedded("e1", "en")]
+        XCTAssertNil(LanguagePreferenceResolver.pick(from: tracks, preferred: "OFF"))
+        XCTAssertNil(LanguagePreferenceResolver.pick(from: tracks, preferred: "Off"))
+    }
+
+    func test_exactMatch_returnsTrack() {
+        let tracks = [embedded("e1", "en")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "en")
+        XCTAssertEqual(pick?.id, "e1")
+    }
+
+    func test_primarySubtagMatch_enMatchesEnUS() {
+        let tracks = [embedded("e1", "en-US")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "en")
+        XCTAssertEqual(pick?.id, "e1")
+    }
+
+    func test_primarySubtagMatch_ptBRPickedByPt() {
+        let tracks = [embedded("e1", "pt-BR")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "pt")
+        XCTAssertEqual(pick?.id, "e1")
+    }
+
+    func test_primarySubtagMatch_sharedPrimary_ptBRPickedByPtPT() {
+        // User pref "pt-PT", track "pt-BR" — both share primary "pt".
+        let tracks = [embedded("e1", "pt-BR")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "pt-PT")
+        XCTAssertEqual(pick?.id, "e1")
+    }
+
+    func test_caseInsensitiveMatch() {
+        let tracks = [embedded("e1", "en")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "EN")
+        XCTAssertEqual(pick?.id, "e1")
+    }
+
+    func test_noMatch_returnsNil() {
+        let tracks = [embedded("e1", "en"), sidecar("s1", "fr")]
+        XCTAssertNil(LanguagePreferenceResolver.pick(from: tracks, preferred: "de"))
+    }
+
+    func test_bothMatch_embeddedWinsOverSidecar() {
+        let tracks = [embedded("e1", "en"), sidecar("s1", "en")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "en")
+        XCTAssertEqual(pick?.id, "e1")
+    }
+
+    func test_sidecarOnly_match_returnsSidecar() {
+        let tracks = [sidecar("s1", "en")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "en")
+        XCTAssertEqual(pick?.id, "s1")
+    }
+
+    /// D8 step 3 guarantee: resolver partitions internally. Input order
+    /// doesn't matter — if an embedded match exists anywhere in the list,
+    /// it wins.
+    func test_callerOrderIndependence_sidecarFirstInput_embeddedStillWins() {
+        let tracks = [sidecar("s1", "en"), embedded("e1", "en")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "en")
+        XCTAssertEqual(pick?.id, "e1", "Resolver must partition by source type, not trust caller order.")
+    }
+
+    func test_scriptSubtagCounts_asPrefixHit_zhHansMatchesZh() {
+        let tracks = [embedded("e1", "zh-Hans")]
+        let pick = LanguagePreferenceResolver.pick(from: tracks, preferred: "zh")
+        XCTAssertEqual(pick?.id, "e1")
+    }
+
+    func test_trackLanguageNil_notMatched() {
+        let tracks = [embedded("e1", nil)]
+        XCTAssertNil(LanguagePreferenceResolver.pick(from: tracks, preferred: "en"))
+    }
+
+    // MARK: - Primary subtag helper
+
+    func test_primarySubtag_extractsPrimary() {
+        XCTAssertEqual(LanguagePreferenceResolver.primarySubtag(of: "en-US"), "en")
+        XCTAssertEqual(LanguagePreferenceResolver.primarySubtag(of: "pt-BR"), "pt")
+        XCTAssertEqual(LanguagePreferenceResolver.primarySubtag(of: "zh-Hans"), "zh")
+        XCTAssertEqual(LanguagePreferenceResolver.primarySubtag(of: "en"), "en")
+    }
+}

--- a/Packages/SubtitleDomain/Tests/SubtitleDomainTests/SRTParserTests.swift
+++ b/Packages/SubtitleDomain/Tests/SubtitleDomainTests/SRTParserTests.swift
@@ -1,0 +1,236 @@
+import CoreMedia
+import XCTest
+@testable import SubtitleDomain
+
+final class SRTParserTests: XCTestCase {
+
+    // MARK: - Happy paths
+
+    func test_parsesSingleCue() {
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:04,500
+        Hello, world.
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues.count, 1)
+        XCTAssertEqual(cues[0].index, 1)
+        XCTAssertEqual(cues[0].text, "Hello, world.")
+        XCTAssertEqual(cues[0].startTime, CMTime(value: 1_000, timescale: 1_000))
+        XCTAssertEqual(cues[0].endTime, CMTime(value: 4_500, timescale: 1_000))
+    }
+
+    func test_parsesMultipleCues_preservesOrder() {
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        First.
+
+        2
+        00:00:03,000 --> 00:00:04,000
+        Second.
+
+        3
+        00:00:05,000 --> 00:00:06,000
+        Third.
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues.map(\.text), ["First.", "Second.", "Third."])
+        XCTAssertEqual(cues.map(\.index), [1, 2, 3])
+    }
+
+    func test_acceptsCRLFLineEndings() {
+        let srt = "1\r\n00:00:01,000 --> 00:00:02,000\r\nLine one.\r\n"
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues.count, 1)
+        XCTAssertEqual(cues[0].text, "Line one.")
+    }
+
+    func test_acceptsDotAsMillisecondSeparator() {
+        // Some wild SRT files use '.' instead of ',' for ms.
+        let srt = """
+        1
+        00:00:01.500 --> 00:00:02.750
+        ok
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues[0].startTime, CMTime(value: 1_500, timescale: 1_000))
+        XCTAssertEqual(cues[0].endTime, CMTime(value: 2_750, timescale: 1_000))
+    }
+
+    func test_stripsHTMLTags_italicBoldUnderline() {
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        <i>italic</i> <b>bold</b> <u>underline</u>
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues[0].text, "italic bold underline")
+    }
+
+    func test_decodesHTMLEntities() {
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        Tom &amp; Jerry &lt;3 &quot;friends&quot;
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues[0].text, "Tom & Jerry <3 \"friends\"")
+    }
+
+    func test_preservesMultiLineCueText() {
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        Line A
+        Line B
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues[0].text, "Line A\nLine B")
+    }
+
+    func test_preservesOverlappingCues_inOrder() {
+        // Cue 2 starts before cue 1 ends — perfectly legal in SRT.
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:05,000
+        Long cue.
+
+        2
+        00:00:03,000 --> 00:00:04,000
+        Short cue inside it.
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues.count, 2)
+        XCTAssertEqual(cues.map(\.text), ["Long cue.", "Short cue inside it."])
+    }
+
+    func test_preservesTimelineGaps() {
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        First.
+
+        2
+        00:00:10,000 --> 00:00:11,000
+        Much later.
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues[1].startTime, CMTime(value: 10_000, timescale: 1_000))
+    }
+
+    // MARK: - Recoverable slips
+
+    func test_missingIndexLine_usesOrdinal() {
+        // No index line — block starts directly with the timecode.
+        let srt = """
+        00:00:01,000 --> 00:00:02,000
+        no index
+
+        00:00:03,000 --> 00:00:04,000
+        still no index
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues.map(\.index), [1, 2])
+        XCTAssertEqual(cues.map(\.text), ["no index", "still no index"])
+    }
+
+    func test_extraTrailingBlankLines_absorbed() {
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        ok
+
+
+
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues.count, 1)
+    }
+
+    func test_trailingWhitespaceOnTimecode_tolerated() {
+        let srt = "1\n00:00:01,000 --> 00:00:02,000   \nok\n"
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues[0].text, "ok")
+    }
+
+    func test_cuePositionHintsAfterTimecode_ignored() {
+        // Wild-SRT variant: "--> HH:MM:SS,mmm X1:... X2:... Y1:... Y2:..."
+        let srt = """
+        1
+        00:00:01,000 --> 00:00:02,000 X1:100 X2:200 Y1:100 Y2:200
+        ok
+        """
+        let cues = expectSuccess(SRTParser.parse(srt))
+        XCTAssertEqual(cues.count, 1)
+        XCTAssertEqual(cues[0].endTime, CMTime(value: 2_000, timescale: 1_000))
+    }
+
+    // MARK: - Unrecoverable shape
+
+    func test_emptyInput_returnsEmptyArray_notError() {
+        let cues = expectSuccess(SRTParser.parse(""))
+        XCTAssertTrue(cues.isEmpty)
+    }
+
+    func test_whitespaceOnlyInput_returnsEmptyArray() {
+        let cues = expectSuccess(SRTParser.parse("   \n\n   \n"))
+        XCTAssertTrue(cues.isEmpty)
+    }
+
+    func test_badTimecode_returnsDecodingError() {
+        let srt = """
+        1
+        00:00:XX,000 --> 00:00:02,000
+        bad
+        """
+        let result = SRTParser.parse(srt)
+        guard case .failure(let err) = result else {
+            return XCTFail("expected .failure, got \(result)")
+        }
+        if case .decoding = err {} else {
+            XCTFail("expected .decoding, got \(err)")
+        }
+    }
+
+    func test_blockWithoutTimecode_returnsDecodingError() {
+        let srt = """
+        1
+        no timecode here
+        still no timecode
+        """
+        let result = SRTParser.parse(srt)
+        guard case .failure(let err) = result else {
+            return XCTFail("expected .failure, got \(result)")
+        }
+        if case .decoding = err {} else {
+            XCTFail("expected .decoding, got \(err)")
+        }
+    }
+
+    func test_malformedMinutes_returnsDecodingError() {
+        let srt = """
+        1
+        00:99:01,000 --> 00:00:02,000
+        bad minutes
+        """
+        let result = SRTParser.parse(srt)
+        guard case .failure = result else {
+            return XCTFail("expected .failure (minutes ≥ 60), got \(result)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func expectSuccess(_ result: Result<[SubtitleCue], SubtitleLoadError>,
+                               file: StaticString = #filePath,
+                               line: UInt = #line) -> [SubtitleCue] {
+        switch result {
+        case .success(let cues):
+            return cues
+        case .failure(let err):
+            XCTFail("expected .success, got \(err)", file: file, line: line)
+            return []
+        }
+    }
+}

--- a/Packages/SubtitleDomain/Tests/SubtitleDomainTests/SubtitleCueTests.swift
+++ b/Packages/SubtitleDomain/Tests/SubtitleDomainTests/SubtitleCueTests.swift
@@ -1,0 +1,61 @@
+import CoreMedia
+import XCTest
+@testable import SubtitleDomain
+
+final class SubtitleCueTests: XCTestCase {
+
+    func test_equatable_sameFieldsCompareEqual() {
+        let a = SubtitleCue(
+            index: 1,
+            startTime: CMTime(value: 1000, timescale: 1000),
+            endTime: CMTime(value: 2000, timescale: 1000),
+            text: "Hello"
+        )
+        let b = SubtitleCue(
+            index: 1,
+            startTime: CMTime(value: 1000, timescale: 1000),
+            endTime: CMTime(value: 2000, timescale: 1000),
+            text: "Hello"
+        )
+        XCTAssertEqual(a, b)
+    }
+
+    func test_equatable_differentTextComparesUnequal() {
+        let a = SubtitleCue(
+            index: 1,
+            startTime: CMTime(value: 1000, timescale: 1000),
+            endTime: CMTime(value: 2000, timescale: 1000),
+            text: "Hello"
+        )
+        let b = SubtitleCue(
+            index: 1,
+            startTime: CMTime(value: 1000, timescale: 1000),
+            endTime: CMTime(value: 2000, timescale: 1000),
+            text: "Goodbye"
+        )
+        XCTAssertNotEqual(a, b)
+    }
+
+    func test_cmtimeOrdering_startBeforeEnd() {
+        let cue = SubtitleCue(
+            index: 1,
+            startTime: CMTime(value: 1000, timescale: 1000),
+            endTime: CMTime(value: 2000, timescale: 1000),
+            text: "ok"
+        )
+        XCTAssertLessThan(cue.startTime, cue.endTime)
+    }
+
+    func test_sendable_crossActor() async {
+        // Regression guard for `Sendable` conformance: if this compiles
+        // with Swift 6 strict concurrency, the type is Sendable.
+        let cue = SubtitleCue(
+            index: 1,
+            startTime: .zero,
+            endTime: CMTime(value: 1000, timescale: 1000),
+            text: "a"
+        )
+        let copy = await Task.detached { cue }.value
+        XCTAssertEqual(cue, copy)
+    }
+}

--- a/Packages/SubtitleDomain/Tests/SubtitleDomainTests/SubtitleTextDecoderTests.swift
+++ b/Packages/SubtitleDomain/Tests/SubtitleDomainTests/SubtitleTextDecoderTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import SubtitleDomain
+
+final class SubtitleTextDecoderTests: XCTestCase {
+
+    func test_decodesPlainUTF8() {
+        let data = Data("1\n00:00:01,000 --> 00:00:02,000\nhello\n".utf8)
+        let result = SubtitleTextDecoder.decode(data)
+        guard case .success(let text) = result else {
+            return XCTFail("expected .success, got \(result)")
+        }
+        XCTAssertTrue(text.contains("hello"))
+        XCTAssertFalse(text.contains("\u{FEFF}"))
+    }
+
+    func test_decodesUTF8WithBOM_stripsBOM() {
+        var data = Data([0xEF, 0xBB, 0xBF])
+        data.append(Data("hello".utf8))
+        let result = SubtitleTextDecoder.decode(data)
+        guard case .success(let text) = result else {
+            return XCTFail("expected .success, got \(result)")
+        }
+        XCTAssertEqual(text, "hello", "BOM must be stripped, not kept in the string.")
+    }
+
+    func test_decodesWindowsCP1252_smartQuotes() {
+        // 0x93 and 0x94 are Windows-1252 smart quotes; not valid UTF-8.
+        let bytes: [UInt8] = [0x93, 0x68, 0x69, 0x94] // "hi"
+        let data = Data(bytes)
+        let result = SubtitleTextDecoder.decode(data)
+        guard case .success(let text) = result else {
+            return XCTFail("expected .success, got \(result)")
+        }
+        XCTAssertTrue(text.contains("hi"))
+        // The smart quotes should decode to curly-quote characters.
+        XCTAssertTrue(text.contains("\u{201C}") || text.contains("\u{201D}"),
+                      "CP1252 smart quotes should decode to curly-quote characters.")
+    }
+
+    func test_decodesISO8859_1_fallback() {
+        // Plain Latin-1 bytes: 0xE9 == 'é'. Invalid in UTF-8, and
+        // differently interpreted in CP1252 (0xE9 is also 'é' in both,
+        // so this case is really just a sanity check that we don't
+        // reject it).
+        let bytes: [UInt8] = [0x68, 0xE9, 0x6C, 0x6C, 0x6F] // "héllo"
+        let data = Data(bytes)
+        let result = SubtitleTextDecoder.decode(data)
+        guard case .success(let text) = result else {
+            return XCTFail("expected .success, got \(result)")
+        }
+        XCTAssertTrue(text.contains("é"))
+    }
+
+    func test_rejectsBinaryData_decoding() {
+        // Lots of NULs and random control bytes.
+        let bytes: [UInt8] = Array(repeating: 0x00, count: 20) + [0xFF, 0xFE, 0xFD] + Array(repeating: 0x01, count: 20)
+        let data = Data(bytes)
+        let result = SubtitleTextDecoder.decode(data)
+        guard case .failure(let err) = result else {
+            return XCTFail("expected .failure, got \(result)")
+        }
+        if case .decoding = err {} else {
+            XCTFail("expected .decoding, got \(err)")
+        }
+    }
+
+    func test_emptyData_succeedsAsEmptyString() {
+        let result = SubtitleTextDecoder.decode(Data())
+        guard case .success(let text) = result else {
+            return XCTFail("expected .success, got \(result)")
+        }
+        XCTAssertEqual(text, "")
+    }
+
+    // MARK: - Heuristic unit
+
+    func test_isLikelyText_allASCII_passes() {
+        let data = Data("hello world".utf8)
+        XCTAssertTrue(SubtitleTextDecoder.isLikelyText(data))
+    }
+
+    func test_isLikelyText_mostlyNULs_rejects() {
+        let data = Data(Array(repeating: UInt8(0), count: 100))
+        XCTAssertFalse(SubtitleTextDecoder.isLikelyText(data))
+    }
+
+    func test_hasUTF8BOM_detectsBOM() {
+        let withBom = Data([0xEF, 0xBB, 0xBF, 0x61])
+        XCTAssertTrue(SubtitleTextDecoder.hasUTF8BOM(withBom))
+
+        let withoutBom = Data("a".utf8)
+        XCTAssertFalse(SubtitleTextDecoder.hasUTF8BOM(withoutBom))
+    }
+}


### PR DESCRIPTION
## Summary

Foundation PR for Epic #4 Phase 2. Lands `Packages/SubtitleDomain` with every type and pure-logic unit in [`docs/design/subtitle-foundation.md`](../blob/main/docs/design/subtitle-foundation.md). No UI, no AVKit coupling.

## What lands

- **`Packages/SubtitleDomain`** — new pure-Swift package (no AppKit/UIKit/AVKit imports; only `Foundation` and `CoreMedia`):
  - `SubtitleCue` — 1-based index, `CMTime` start/end, plain-text payload.
  - `SubtitleFormat` — `.srt`, `.webVTT`, `.movText`, `.closedCaption`.
  - `SubtitleSource` — `.embedded(identifier:)` / `.sidecar(url:, format:, cues:)`. Cues live in the sidecar payload per design doc D3.
  - `SubtitleTrack` — `id`, `source`, `language?` (BCP-47), `label`.
  - `SubtitleLoadError` — `.fileUnavailable`, `.decoding`, `.unsupportedFormat`, `.systemTrackFailed`.
  - `SubtitleTextDecoder` — UTF-8 (with BOM stripping) → Windows-1252 → ISO-8859-1, with a NUL/control-byte heuristic to reject binary.
  - `SRTParser` — timecode parser accepts `,` and `.` separators; absorbs missing indices, trailing blanks, and wild-SRT position hints; surfaces `.decoding` on malformed timecodes or blocks without a `-->` marker. Light tag stripping (`<i>`, `<b>`, `<u>`) and HTML entity decoding (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`).
  - `LanguagePreferenceResolver` — **partitions internally** by source type; embedded wins on tie regardless of caller input order. BCP-47 case-insensitive primary-subtag match.
- **CI** — `Packages/SubtitleDomain` added to the `swift test` matrix alongside PlannerCore / EngineInterface / XPCMapping / EngineStore / LibraryDomain.

## Tests — 46 green locally

- `SRTParserTests` (19) — single/multi/CRLF, dot-separator, tag stripping, entity decoding, multi-line cues, overlaps, gaps, position-hint stripping, missing-index recovery, trailing blanks, empty → `[]`, whitespace-only → `[]`, bad timecode → `.decoding`, block-without-timecode → `.decoding`, out-of-range minutes → `.decoding`.
- `SubtitleTextDecoderTests` (9) — UTF-8, UTF-8 with BOM, Windows-1252 smart quotes, ISO-8859-1 fallback, binary rejection, empty data, heuristic unit tests, BOM detector.
- `LanguagePreferenceResolverTests` (14) — every resolution-matrix row plus the **caller-order-independence** row mandated by design doc D8 (sidecar first in input + matching embedded later → embedded still wins).
- `SubtitleCueTests` (4) — `Equatable`, `CMTime` ordering, `Sendable` cross-actor.

## Xcode project wiring

Deferred to #28 (first app-side consumer of `SubtitleDomain`). Pattern mirrors Phase 1 — `LibraryDomain` also lands first as a Swift package with CI coverage; the app target integration rides with the first consumer PR.

## Test plan

- [x] `swift test --package-path Packages/SubtitleDomain` passes (46 tests, 0 failures).
- [x] All other existing packages still build (CI will confirm).
- [x] No AVKit / AppKit / UIKit imports in the new package — verified by grep.

Closes #27
Refs #4, #28, #29, #30, #32