### PR TITLE
feat(player): PlayerState foundation (epic #3 phase 3, #18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           swift test --package-path Packages/EngineStore
           swift test --package-path Packages/LibraryDomain
           swift test --package-path Packages/SubtitleDomain
+          swift test --package-path Packages/PlayerDomain
 
       - name: Snapshot tests (advisory — pixel drift on CI vs local)
         # CI runners don't have the owner's personal signing certificate for

--- a/App/Features/Player/PlayerView.swift
+++ b/App/Features/Player/PlayerView.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import EngineInterface
+import PlayerDomain
 import SwiftUI
 
 // MARK: - PlayerView
@@ -36,9 +37,11 @@ struct PlayerView: View {
                     .ignoresSafeArea()
             }
 
-            // Error overlay — only shown if player initialisation failed.
-            if let errorMessage = viewModel.error {
-                errorOverlay(errorMessage)
+            // Error overlay — derived from PlayerState per Phase 3 design.
+            // #26 will replace this minimal text with brand-compliant
+            // per-error-case chrome and a Retry affordance.
+            if case .error(let err) = viewModel.state {
+                errorOverlay(displayMessage(for: err))
             }
 
             // HUD overlay — floats at bottom centre, 24 pt margin.
@@ -96,6 +99,21 @@ struct PlayerView: View {
     }
 
     // MARK: - Error overlay
+
+    /// Map a `PlayerError` to interim display copy. #26 owns the final
+    /// brand-voice copy + retry chrome; this is the minimal seam.
+    private func displayMessage(for error: PlayerError) -> String {
+        switch error {
+        case .streamOpenFailed(let code):
+            return "We couldn't open this stream (engine code \(code.rawValue))."
+        case .xpcDisconnected:
+            return "We lost contact with the engine."
+        case .playbackFailed:
+            return "Playback couldn't continue."
+        case .streamLost:
+            return "The stream is no longer available."
+        }
+    }
 
     private func errorOverlay(_ message: String) -> some View {
         VStack(spacing: 8) {

--- a/App/Features/Player/PlayerViewModel.swift
+++ b/App/Features/Player/PlayerViewModel.swift
@@ -2,21 +2,33 @@ import AVFoundation
 import Combine
 import EngineInterface
 import Foundation
+import PlayerDomain
 
 // MARK: - PlayerViewModel
 
-/// Bridges `EngineClient` to the SwiftUI player view.
+/// Bridges `EngineClient` and AVKit to the SwiftUI player view, driving every
+/// state change through `PlayerStateMachine` (Phase 3 foundation, design at
+/// `docs/design/player-state-foundation.md`).
 ///
-/// Owns `AVPlayer` lifetime and subscribes to `StreamHealthDTO` events
-/// filtered by the active stream ID. All published properties are updated
-/// on the main actor.
+/// Owns `AVPlayer` lifetime. Publishes `state: PlayerState` (the canonical
+/// state-machine projection) and `health: StreamHealthDTO?` (kept as a
+/// separate surface for `StreamHealthHUD` which renders the full DTO, not
+/// just the tier — `PlayerState` carries no DTO).
+///
+/// Engine event projection lives here, not in the state machine. The machine
+/// never imports `EngineInterface` or AVKit; it only sees `PlayerEvent` values.
 @MainActor
 final class PlayerViewModel: ObservableObject {
 
     // MARK: Published
 
+    /// Canonical state-machine projection. The view renders chrome from this.
+    @Published private(set) var state: PlayerState = .closed
+
+    /// Full health DTO for the HUD. Carried alongside `state` because the
+    /// HUD needs `secondsBufferedAhead`, peer count, etc. — fields the
+    /// state machine deliberately doesn't carry.
     @Published private(set) var health: StreamHealthDTO?
-    @Published private(set) var error: String?
 
     // MARK: Internal
 
@@ -27,19 +39,30 @@ final class PlayerViewModel: ObservableObject {
 
     private let streamDescriptor: StreamDescriptorDTO
     private let engineClient: EngineClient
+    private let now: () -> Date
     private var healthSubscription: AnyCancellable?
     private var reconnectSubscription: AnyCancellable?
+    private var avPlayerObservers = Set<AnyCancellable>()
     private var cancellables = Set<AnyCancellable>()
     private var isClosed = false
+    private var hasPriorEvents = false   // edge detection for disconnect/reconnect
 
     // MARK: - Init
 
-    init(streamDescriptor: StreamDescriptorDTO, engineClient: EngineClient) {
+    init(streamDescriptor: StreamDescriptorDTO,
+         engineClient: EngineClient,
+         now: @escaping () -> Date = Date.init) {
         self.streamDescriptor = streamDescriptor
         self.engineClient = engineClient
+        self.now = now
+
+        // Project the (already-completed) open through the state machine so
+        // every consumer sees state move .closed → .buffering(.openingStream)
+        // → .open (or → .error on URL failure).
+        handle(.userRequestedOpen)
 
         guard let url = URL(string: streamDescriptor.loopbackURL as String) else {
-            self.error = "Invalid stream URL: \(streamDescriptor.loopbackURL)"
+            handle(.engineReturnedOpenError(.streamOpenFailed))
             return
         }
 
@@ -47,12 +70,14 @@ final class PlayerViewModel: ObservableObject {
         let avPlayer = AVPlayer(playerItem: item)
         self.player = avPlayer
 
+        handle(.engineReturnedDescriptor)
+
         // Resume seek if a prior byte offset was persisted.
-        // AVPlayer seeks by time, not bytes — we derive approximate time
-        // from the byte ratio once the asset duration is known.
         if streamDescriptor.resumeByteOffset > 0 {
             scheduleResumeSeek(player: avPlayer, item: item)
         }
+
+        bindAVPlayerObservers(player: avPlayer, item: item)
 
         // Re-bind to the active events stream whenever EngineClient reconnects.
         reconnectSubscription = NotificationCenter.default.publisher(
@@ -61,30 +86,75 @@ final class PlayerViewModel: ObservableObject {
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] _ in
-            Task { await self?.subscribeToHealth() }
+            Task { await self?.handleReconnectNotification() }
         }
 
         // Subscribe to the current health stream.
         Task { await self.subscribeToHealth() }
     }
 
-    // MARK: - Playback controls
+    // MARK: - Public controls (project user actions to events)
 
     func play() {
-        player?.play()
+        handle(.userTappedPlay)
     }
 
     func pause() {
-        player?.pause()
+        handle(.userTappedPause)
     }
 
     /// Pauses, closes the stream with the engine, and releases the player.
     /// Safe to call multiple times — subsequent calls are no-ops.
     func close() {
         guard !isClosed else { return }
+        handle(.userTappedClose)
+    }
+
+    func retry() {
+        handle(.userTappedRetry)
+    }
+
+    // MARK: - Event handling
+
+    /// Apply a `PlayerEvent` through the state machine and perform the side
+    /// effects implied by the resulting transition. The state machine is
+    /// pure; this method is where AVPlayer / engine-client calls happen.
+    private func handle(_ event: PlayerEvent) {
+        let previous = state
+        let next = PlayerStateMachine.apply(event, to: previous, now: now())
+        state = next
+
+        // Side effects keyed off (event, previous → next) edges.
+        switch (previous, event, next) {
+
+        case (_, .userTappedClose, .closed):
+            performClose()
+
+        case (.error, .userTappedRetry, .buffering(.openingStream)):
+            // Reissue openStream via the existing path — handled by the
+            // caller that originally constructed this VM. For v1 we surface
+            // the retry intent on `state`; the calling view re-creates a
+            // fresh PlayerViewModel against the same descriptor. (Direct
+            // engine.openStream re-issue from inside the VM is deferred —
+            // see #26 for the full retry plumbing.)
+            break
+
+        case (_, .userTappedPlay, .playing):
+            player?.play()
+
+        case (_, .userTappedPause, .paused):
+            player?.pause()
+
+        default:
+            break
+        }
+    }
+
+    private func performClose() {
         isClosed = true
         healthSubscription?.cancel()
         reconnectSubscription?.cancel()
+        avPlayerObservers.removeAll()
         healthSubscription = nil
         reconnectSubscription = nil
         cancellables.removeAll()
@@ -96,28 +166,108 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Private helpers
+    // MARK: - Engine event projection
 
     /// Subscribe to StreamHealth events for this stream.
     private func subscribeToHealth() async {
-        guard let events = await engineClient.events else { return }
+        guard let events = await engineClient.events else {
+            // events became nil — disconnect edge.
+            if hasPriorEvents {
+                hasPriorEvents = false
+                await MainActor.run { self.handle(.engineDisconnected) }
+            }
+            return
+        }
         guard !isClosed else { return }
         let targetID = streamDescriptor.streamID as String
+
+        // hasPriorEvents transitions detect reconnect on next call; first
+        // successful subscribe simply records the events handle.
+        let wasConnected = hasPriorEvents
+        hasPriorEvents = true
+
+        if !wasConnected && state == .error(.xpcDisconnected) {
+            // Reconnected from a disconnected error state: project the
+            // reconnect signal but per design D6 the state machine will
+            // not auto-resume — user must tap Retry.
+            handle(.engineReconnected)
+        }
 
         healthSubscription?.cancel()
         healthSubscription = events.streamHealthChangedSubject
             .filter { ($0.streamID as String) == targetID }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] dto in
-                self?.health = dto
+                guard let self else { return }
+                self.health = dto
+                self.handle(.engineHealthChanged(dto.tierValue))
             }
     }
+
+    private func handleReconnectNotification() async {
+        // Edge: events went nil → valid OR valid → nil. Inspect.
+        let events = await engineClient.events
+        if events == nil {
+            if hasPriorEvents {
+                hasPriorEvents = false
+                handle(.engineDisconnected)
+            }
+        } else {
+            await subscribeToHealth()
+        }
+    }
+
+    // MARK: - AVPlayer observation
+
+    private func bindAVPlayerObservers(player: AVPlayer, item: AVPlayerItem) {
+        // timeControlStatus → playing/stalled/paused projection
+        player.publisher(for: \.timeControlStatus)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                guard let self else { return }
+                switch status {
+                case .playing:
+                    self.handle(.avPlayerBeganPlaying)
+                case .waitingToPlayAtSpecifiedRate:
+                    self.handle(.avPlayerStalled)
+                case .paused:
+                    // Don't project: user-initiated pause is driven via
+                    // `userTappedPause`; KVO `.paused` would double-fire.
+                    break
+                @unknown default:
+                    break
+                }
+            }
+            .store(in: &avPlayerObservers)
+
+        item.publisher(for: \.isPlaybackBufferEmpty)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] empty in
+                if empty { self?.handle(.avPlayerStalled) }
+            }
+            .store(in: &avPlayerObservers)
+
+        item.publisher(for: \.isPlaybackLikelyToKeepUp)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] keepUp in
+                if keepUp { self?.handle(.avPlayerResumed) }
+            }
+            .store(in: &avPlayerObservers)
+
+        item.publisher(for: \.status)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                if status == .failed { self?.handle(.avPlayerFailed) }
+            }
+            .store(in: &avPlayerObservers)
+    }
+
+    // MARK: - Private helpers
 
     /// Once the asset duration is available, seeks to the byte-ratio–derived time.
     /// This is a best-effort approximation; the planner and gateway handle actual
     /// piece scheduling from the correct offset.
     private func scheduleResumeSeek(player: AVPlayer, item: AVPlayerItem) {
-        // Wait for the item to become ready so duration is valid.
         item.publisher(for: \.status)
             .filter { $0 == .readyToPlay }
             .first()
@@ -135,9 +285,10 @@ final class PlayerViewModel: ObservableObject {
                     / Double(self.streamDescriptor.contentLength)
                 let seekSeconds = item.duration.seconds * ratio
                 let seekTime = CMTime(seconds: seekSeconds, preferredTimescale: 600)
-                player.seek(to: seekTime, toleranceBefore: .zero, toleranceAfter: CMTime(seconds: 5, preferredTimescale: 600))
+                player.seek(to: seekTime,
+                            toleranceBefore: .zero,
+                            toleranceAfter: CMTime(seconds: 5, preferredTimescale: 600))
             }
             .store(in: &cancellables)
     }
-
 }

--- a/ButterBar.xcodeproj/project.pbxproj
+++ b/ButterBar.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		AA11BB22CC33DD44EE55FF66 /* EngineClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF66EE55DD44CC33BB22AA11 /* EngineClient.swift */; };
 		AA11BB33CC55DD77EE99FF11 /* EngineStore in Frameworks */ = {isa = PBXBuildFile; productRef = FF66AA88BB00CC22DD44EE66 /* EngineStore */; };
 		FACE0001AAAA0000BBBB0001 /* LibraryDomain in Frameworks */ = {isa = PBXBuildFile; productRef = FACE0004AAAA0000BBBB0004 /* LibraryDomain */; };
+		B11E0001000000000000BB01 /* PlayerDomain in Frameworks */ = {isa = PBXBuildFile; productRef = B11E0004000000000000BB04 /* PlayerDomain */; };
 		AA33BB55CC77DD99EE11FF33 /* ResumeTrackerSelfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6600889900AABB11CC2233 /* ResumeTrackerSelfTest.swift */; };
 		AA77889900BBCCDD11AA7788 /* HTTPSelfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8899AA00CCDDEE22BB8899 /* HTTPSelfTest.swift */; };
 		B5C7D9E1F3A2048A67B9C0D1 /* TorrentBridgeSmokeTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = F8C1D5A3B2E497640F3A5B02 /* TorrentBridgeSmokeTest.mm */; };
@@ -156,6 +157,7 @@
 		DD44EE55FF6677AA88BB99CC /* DTOSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTOSendable.swift; sourceTree = "<group>"; };
 		DD44EE66FF88AA00BB22CC44 /* EngineStore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = EngineStore; path = Packages/EngineStore; sourceTree = "<group>"; };
 		FACE0002AAAA0000BBBB0002 /* LibraryDomain */ = {isa = PBXFileReference; lastKnownFileType = folder; name = LibraryDomain; path = Packages/LibraryDomain; sourceTree = "<group>"; };
+		B11E0002000000000000BB02 /* PlayerDomain */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PlayerDomain; path = Packages/PlayerDomain; sourceTree = "<group>"; };
 		E1000002000000000000EE02 /* CacheEvictionProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheEvictionProbe.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E1F2A3B4C5D6 /* ByteReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteReader.swift; sourceTree = "<group>"; };
 		E2000002000000000000EE02 /* CacheEviction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheEviction.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				5449C4D2390E0AAD7914583D /* EngineInterface in Frameworks */,
 				97D6C5379559B125DE089050 /* PlannerCore in Frameworks */,
 				FACE0001AAAA0000BBBB0001 /* LibraryDomain in Frameworks */,
+				B11E0001000000000000BB01 /* PlayerDomain in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -391,6 +394,7 @@
 				1785E418002BEE10CA7FEDC0 /* TestFixtures */,
 				DD44EE66FF88AA00BB22CC44 /* EngineStore */,
 				FACE0002AAAA0000BBBB0002 /* LibraryDomain */,
+				B11E0002000000000000BB02 /* PlayerDomain */,
 			);
 			name = Packages;
 			sourceTree = "<group>";
@@ -449,6 +453,7 @@
 				29ED0EA0014C4BEC558549BB /* EngineInterface */,
 				BDA7E17795E9B0C29D6E029A /* PlannerCore */,
 				FACE0004AAAA0000BBBB0004 /* LibraryDomain */,
+				B11E0004000000000000BB04 /* PlayerDomain */,
 			);
 			productName = ButterBar;
 			productReference = 67921BA991E985B2A97454A8 /* ButterBar.app */;
@@ -533,6 +538,7 @@
 				2E61653CC56FA54DED6A53B7 /* XCLocalSwiftPackageReference "Packages/TestFixtures" */,
 				EE55FF77AA99BB11CC33DD55 /* XCLocalSwiftPackageReference "Packages/EngineStore" */,
 				FACE0003AAAA0000BBBB0003 /* XCLocalSwiftPackageReference "Packages/LibraryDomain" */,
+				B11E0003000000000000BB03 /* XCLocalSwiftPackageReference "Packages/PlayerDomain" */,
 				390C8C7D7247342CD8100F2F /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 			);
 			productRefGroup = 21A59A6D24B4DEA9DB9C5973 /* Products */;
@@ -1316,6 +1322,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/LibraryDomain;
 		};
+		B11E0003000000000000BB03 /* XCLocalSwiftPackageReference "Packages/PlayerDomain" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/PlayerDomain;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1364,6 +1374,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FACE0003AAAA0000BBBB0003 /* XCLocalSwiftPackageReference "Packages/LibraryDomain" */;
 			productName = LibraryDomain;
+		};
+		B11E0004000000000000BB04 /* PlayerDomain */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B11E0003000000000000BB03 /* XCLocalSwiftPackageReference "Packages/PlayerDomain" */;
+			productName = PlayerDomain;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Packages/EngineInterface/Sources/EngineInterface/EngineErrorCode.swift
+++ b/Packages/EngineInterface/Sources/EngineInterface/EngineErrorCode.swift
@@ -4,7 +4,11 @@ import Foundation
 public let EngineErrorDomain = "com.butterbar.engine"
 
 /// Stable error codes for the `com.butterbar.engine` domain.
-@objc public enum EngineErrorCode: Int {
+///
+/// `Sendable` because every value is a primitive Int discriminator — no
+/// reference state, no mutability. Required for use as an associated value
+/// inside `Sendable` enums (e.g. `PlayerError.streamOpenFailed(_)`).
+@objc public enum EngineErrorCode: Int, Sendable {
     /// The requested method is not yet implemented.
     case notImplemented = 1
     /// The supplied magnet link or torrent data is malformed.

--- a/Packages/PlayerDomain/Package.swift
+++ b/Packages/PlayerDomain/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "PlayerDomain",
+    platforms: [
+        .macOS(.v26)
+    ],
+    products: [
+        .library(name: "PlayerDomain", targets: ["PlayerDomain"])
+    ],
+    dependencies: [
+        .package(path: "../EngineInterface")
+    ],
+    targets: [
+        .target(
+            name: "PlayerDomain",
+            dependencies: [
+                .product(name: "EngineInterface", package: "EngineInterface")
+            ],
+            path: "Sources/PlayerDomain"
+        ),
+        .testTarget(
+            name: "PlayerDomainTests",
+            dependencies: ["PlayerDomain"],
+            path: "Tests/PlayerDomainTests"
+        )
+    ]
+)

--- a/Packages/PlayerDomain/Sources/PlayerDomain/PlayerEvent.swift
+++ b/Packages/PlayerDomain/Sources/PlayerDomain/PlayerEvent.swift
@@ -1,0 +1,51 @@
+import EngineInterface
+import Foundation
+
+/// Inputs to the `PlayerStateMachine`. Projected from engine events, AVKit
+/// signals, and user actions by the calling `PlayerViewModel` per design
+/// `docs/design/player-state-foundation.md § D5`.
+///
+/// The machine never imports AVKit and never inspects a `StreamHealthDTO`
+/// directly — projection happens at the VM, the typed event arrives here.
+public enum PlayerEvent: Equatable, Sendable {
+
+    // MARK: - User actions
+
+    /// User asked to open the file (e.g. tapped a row in the library).
+    case userRequestedOpen
+    /// User tapped the play button in the overlay.
+    case userTappedPlay
+    /// User tapped the pause button in the overlay.
+    case userTappedPause
+    /// User tapped close / dismissed the player window.
+    case userTappedClose
+    /// User tapped "Retry" from an error state (#26).
+    case userTappedRetry
+
+    // MARK: - Engine signals
+
+    /// `engine.openStream` reply with a non-nil descriptor.
+    /// The descriptor itself is held by the VM; the machine only needs to
+    /// know the open succeeded.
+    case engineReturnedDescriptor
+    /// `engine.openStream` reply with a non-nil `NSError`.
+    case engineReturnedOpenError(EngineErrorCode)
+    /// `EngineEvents.streamHealthChanged(dto)` filtered to this stream.
+    /// Tier converted to the typed enum at the mapping layer.
+    case engineHealthChanged(StreamHealthTier)
+    /// `EngineClient.events` went `valid → nil` (edge-triggered).
+    case engineDisconnected
+    /// `EngineClient.events` went `nil → valid` (edge-triggered).
+    case engineReconnected
+
+    // MARK: - AVKit signals
+
+    /// `AVPlayer.timeControlStatus` rose to `.playing`.
+    case avPlayerBeganPlaying
+    /// `AVPlayerItem.isPlaybackBufferEmpty` rose edge.
+    case avPlayerStalled
+    /// `AVPlayerItem.isPlaybackLikelyToKeepUp` rose edge after a stall.
+    case avPlayerResumed
+    /// `AVPlayerItem.status` → `.failed`.
+    case avPlayerFailed
+}

--- a/Packages/PlayerDomain/Sources/PlayerDomain/PlayerState.swift
+++ b/Packages/PlayerDomain/Sources/PlayerDomain/PlayerState.swift
@@ -1,0 +1,53 @@
+import EngineInterface
+import Foundation
+
+/// One stream's playback state inside a `PlayerViewModel`.
+///
+/// Six cases per the Phase 3 design (`docs/design/player-state-foundation.md`
+/// § D2). The pre-open "loading" phase folds into `.buffering(.openingStream)`
+/// rather than a 7th `.opening` case — the surface a user sees ("we're waiting
+/// on bytes") is the same in both situations; the internal `BufferingReason`
+/// distinguishes for telemetry, copy, and tests.
+///
+/// Carries no `streamID` / `torrentID` / `fileIndex` — identity is owned by
+/// the calling `PlayerViewModel`, mirroring `WatchStatus` (Phase 1).
+public enum PlayerState: Equatable, Sendable {
+    /// Initial and terminal — no descriptor, no AVPlayer attached.
+    case closed
+    /// Descriptor in hand, AVPlayer attached, rate is 0. The resume-prompt
+    /// window. Distinct from `.paused`: `.paused` implies user intent.
+    case open
+    /// `AVPlayer.rate > 0` and engine tier is not `.starving`.
+    case playing
+    /// `AVPlayer.rate == 0` because the user paused.
+    case paused
+    /// Three distinct gates that all render as "we are waiting on bytes".
+    case buffering(reason: BufferingReason)
+    /// Recoverable from the model's perspective via retry; terminal from
+    /// this stream's perspective.
+    case error(PlayerError)
+}
+
+/// Why we are buffering. See `docs/design/player-state-foundation.md § D2`.
+public enum BufferingReason: Equatable, Sendable {
+    /// Awaiting the engine's `openStream` reply (replaces a separate
+    /// `.opening` state).
+    case openingStream
+    /// `StreamHealthTier == .starving`.
+    case engineStarving
+    /// `AVPlayerItem.isPlaybackBufferEmpty == true`.
+    case playerRebuffering
+}
+
+/// Errors that drive `PlayerState.error(_)`. See design § D2.
+public enum PlayerError: Equatable, Sendable {
+    /// `engine.openStream` reply contained an `NSError`.
+    case streamOpenFailed(EngineErrorCode)
+    /// `EngineClient` lost the XPC connection.
+    case xpcDisconnected
+    /// `AVPlayerItem.status == .failed`.
+    case playbackFailed
+    /// Engine has stopped serving this stream without telling us. Reserved
+    /// for design § Open questions O1; not reachable in v1.
+    case streamLost
+}

--- a/Packages/PlayerDomain/Sources/PlayerDomain/PlayerStateMachine.swift
+++ b/Packages/PlayerDomain/Sources/PlayerDomain/PlayerStateMachine.swift
@@ -1,0 +1,168 @@
+import EngineInterface
+import Foundation
+
+/// Pure-function state machine for the player view-model. Mirrors the Phase 1
+/// `WatchStateMachine` discipline (addendum A3 / Phase 3 design § D4):
+///
+/// - Deterministic: same `(state, event, now)` always yields the same result.
+/// - Pure: no clocks (`now` injected), no I/O, no `DispatchQueue`, no
+///   `Combine`, no randomness, no internal mutable state.
+/// - Side-effect free: applying an event returns a new `PlayerState`; the
+///   calling `PlayerViewModel` is responsible for any actual XPC / AVKit
+///   calls implied by the transition.
+///
+/// Tests exercise every cell of the transition matrix in
+/// `docs/design/player-state-foundation.md § Transition matrix`.
+public enum PlayerStateMachine {
+
+    /// Apply `event` to `state`, producing the new state as of `now`.
+    public static func apply(_ event: PlayerEvent,
+                             to state: PlayerState,
+                             now: Date) -> PlayerState {
+        switch (state, event) {
+
+        // MARK: - .closed
+
+        case (.closed, .userRequestedOpen):
+            return .buffering(reason: .openingStream)
+        case (.closed, _):
+            // Every other event is either an invariant violation or a no-op.
+            // Per design § Transition matrix all stay `.closed`.
+            return .closed
+
+        // MARK: - .open
+
+        case (.open, .userTappedPlay),
+             (.open, .avPlayerBeganPlaying):
+            return .playing
+        case (.open, .userTappedPause):
+            return .paused
+        case (.open, .userTappedClose):
+            return .closed
+        case (.open, .avPlayerStalled):
+            return .buffering(reason: .playerRebuffering)
+        case (.open, .avPlayerFailed):
+            return .error(.playbackFailed)
+        case (.open, .engineHealthChanged(let tier)):
+            return tier == .starving
+                ? .buffering(reason: .engineStarving)
+                : .open
+        case (.open, .engineDisconnected):
+            return .error(.xpcDisconnected)
+        case (.open, _):
+            // Idempotent / invariant: userRequestedOpen, engineReturnedDescriptor,
+            // engineReturnedOpenError, userTappedRetry, avPlayerResumed,
+            // engineReconnected (no auto-resume per D6).
+            return .open
+
+        // MARK: - .playing
+
+        case (.playing, .userTappedPause):
+            return .paused
+        case (.playing, .userTappedClose):
+            return .closed
+        case (.playing, .avPlayerStalled):
+            return .buffering(reason: .playerRebuffering)
+        case (.playing, .avPlayerFailed):
+            return .error(.playbackFailed)
+        case (.playing, .engineHealthChanged(let tier)):
+            return tier == .starving
+                ? .buffering(reason: .engineStarving)
+                : .playing
+        case (.playing, .engineDisconnected):
+            return .error(.xpcDisconnected)
+        case (.playing, _):
+            // Idempotent / invariant: userRequestedOpen, engineReturned*,
+            // userTappedPlay, userTappedRetry, avPlayerBeganPlaying,
+            // avPlayerResumed, engineReconnected.
+            return .playing
+
+        // MARK: - .paused
+
+        case (.paused, .userTappedPlay):
+            return .playing
+        case (.paused, .userTappedClose):
+            return .closed
+        case (.paused, .avPlayerFailed):
+            return .error(.playbackFailed)
+        case (.paused, .engineDisconnected):
+            return .error(.xpcDisconnected)
+        case (.paused, _):
+            // Idempotent / invariant: every other event leaves paused
+            // unchanged (engine starvation suppressed while paused — health
+            // visible in HUD only; spurious AVPlayer signals ignored).
+            return .paused
+
+        // MARK: - .buffering(.openingStream)
+
+        case (.buffering(.openingStream), .engineReturnedDescriptor):
+            return .open
+        case (.buffering(.openingStream), .engineReturnedOpenError(let code)):
+            return .error(.streamOpenFailed(code))
+        case (.buffering(.openingStream), .userTappedClose):
+            return .closed
+        case (.buffering(.openingStream), .engineDisconnected):
+            return .error(.xpcDisconnected)
+        case (.buffering(.openingStream), _):
+            // All else (idempotent open, invariant user/avPlayer events,
+            // engineHealth no-op pre-open, reconnect stays buffering).
+            return .buffering(reason: .openingStream)
+
+        // MARK: - .buffering(.engineStarving)
+
+        case (.buffering(.engineStarving), .userTappedPause):
+            return .paused
+        case (.buffering(.engineStarving), .userTappedClose):
+            return .closed
+        case (.buffering(.engineStarving), .avPlayerBeganPlaying):
+            // Race: AVPlayer began before engine sent the recovered tier.
+            // Accept — AVPlayer rate is ground truth.
+            return .playing
+        case (.buffering(.engineStarving), .avPlayerStalled):
+            // Reason swap: player-side stall while engine still starving.
+            return .buffering(reason: .playerRebuffering)
+        case (.buffering(.engineStarving), .avPlayerFailed):
+            return .error(.playbackFailed)
+        case (.buffering(.engineStarving), .engineHealthChanged(let tier)):
+            return tier == .starving
+                ? .buffering(reason: .engineStarving)
+                : .playing
+        case (.buffering(.engineStarving), .engineDisconnected):
+            return .error(.xpcDisconnected)
+        case (.buffering(.engineStarving), _):
+            return .buffering(reason: .engineStarving)
+
+        // MARK: - .buffering(.playerRebuffering)
+
+        case (.buffering(.playerRebuffering), .userTappedPause):
+            return .paused
+        case (.buffering(.playerRebuffering), .userTappedClose):
+            return .closed
+        case (.buffering(.playerRebuffering), .avPlayerBeganPlaying),
+             (.buffering(.playerRebuffering), .avPlayerResumed):
+            return .playing
+        case (.buffering(.playerRebuffering), .avPlayerFailed):
+            return .error(.playbackFailed)
+        case (.buffering(.playerRebuffering), .engineHealthChanged(let tier)):
+            // Engine wins precedence: starving overrides player-rebuffering.
+            return tier == .starving
+                ? .buffering(reason: .engineStarving)
+                : .buffering(reason: .playerRebuffering)
+        case (.buffering(.playerRebuffering), .engineDisconnected):
+            return .error(.xpcDisconnected)
+        case (.buffering(.playerRebuffering), _):
+            return .buffering(reason: .playerRebuffering)
+
+        // MARK: - .error(_)
+
+        case (.error, .userTappedClose):
+            return .closed
+        case (.error, .userTappedRetry):
+            return .buffering(reason: .openingStream)
+        case (.error, _):
+            // Per design § D6 — reconnect does NOT auto-recover; every other
+            // event is invariant or idempotent against the existing error.
+            return state
+        }
+    }
+}

--- a/Packages/PlayerDomain/Tests/PlayerDomainTests/PlayerStateMachineTests.swift
+++ b/Packages/PlayerDomain/Tests/PlayerDomainTests/PlayerStateMachineTests.swift
@@ -1,0 +1,610 @@
+import EngineInterface
+import XCTest
+@testable import PlayerDomain
+
+/// Drives the `PlayerStateMachine` through every cell of the transition
+/// matrix in `docs/design/player-state-foundation.md § Transition matrix`.
+///
+/// The matrix is 8 states × 14 event families. Many cells are explicit
+/// no-ops or invariant violations (`inv`) — each is asserted explicitly
+/// because silent drops are bugs. Tests are grouped by source state.
+///
+/// `now` is fixed: the v1 state machine is `now`-insensitive (no
+/// transition stamps a timestamp), but the parameter exists so future
+/// transitions can stamp without a refactor.
+final class PlayerStateMachineTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func apply(_ event: PlayerEvent,
+                       to state: PlayerState) -> PlayerState {
+        PlayerStateMachine.apply(event, to: state, now: now)
+    }
+
+    // MARK: - From .closed
+
+    func test_closed_userRequestedOpen_transitionsToBufferingOpeningStream() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: .closed),
+                       .buffering(reason: .openingStream))
+    }
+
+    func test_closed_engineReturnedDescriptor_invariantStaysClosed() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: .closed), .closed)
+    }
+
+    func test_closed_engineReturnedOpenError_invariantStaysClosed() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: .closed), .closed)
+    }
+
+    func test_closed_userTappedPlay_invariantStaysClosed() {
+        XCTAssertEqual(apply(.userTappedPlay, to: .closed), .closed)
+    }
+
+    func test_closed_userTappedPause_invariantStaysClosed() {
+        XCTAssertEqual(apply(.userTappedPause, to: .closed), .closed)
+    }
+
+    func test_closed_userTappedClose_idempotentClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: .closed), .closed)
+    }
+
+    func test_closed_userTappedRetry_invariantStaysClosed() {
+        XCTAssertEqual(apply(.userTappedRetry, to: .closed), .closed)
+    }
+
+    func test_closed_avPlayerBeganPlaying_invariantStaysClosed() {
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: .closed), .closed)
+    }
+
+    func test_closed_avPlayerStalled_invariantStaysClosed() {
+        XCTAssertEqual(apply(.avPlayerStalled, to: .closed), .closed)
+    }
+
+    func test_closed_avPlayerResumed_invariantStaysClosed() {
+        XCTAssertEqual(apply(.avPlayerResumed, to: .closed), .closed)
+    }
+
+    func test_closed_avPlayerFailed_invariantStaysClosed() {
+        XCTAssertEqual(apply(.avPlayerFailed, to: .closed), .closed)
+    }
+
+    func test_closed_engineHealthChanged_noopStaysClosed() {
+        for tier in StreamHealthTier.allCases {
+            XCTAssertEqual(apply(.engineHealthChanged(tier), to: .closed),
+                           .closed,
+                           "tier=\(tier)")
+        }
+    }
+
+    func test_closed_engineDisconnected_staysClosed() {
+        XCTAssertEqual(apply(.engineDisconnected, to: .closed), .closed)
+    }
+
+    func test_closed_engineReconnected_staysClosed() {
+        XCTAssertEqual(apply(.engineReconnected, to: .closed), .closed)
+    }
+
+    // MARK: - From .open
+
+    func test_open_userRequestedOpen_invariantStaysOpen() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: .open), .open)
+    }
+
+    func test_open_engineReturnedDescriptor_idempotentOpen() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: .open), .open)
+    }
+
+    func test_open_engineReturnedOpenError_invariantStaysOpen() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: .open), .open)
+    }
+
+    func test_open_userTappedPlay_transitionsToPlaying() {
+        XCTAssertEqual(apply(.userTappedPlay, to: .open), .playing)
+    }
+
+    func test_open_userTappedPause_transitionsToPaused() {
+        XCTAssertEqual(apply(.userTappedPause, to: .open), .paused)
+    }
+
+    func test_open_userTappedClose_transitionsToClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: .open), .closed)
+    }
+
+    func test_open_userTappedRetry_invariantStaysOpen() {
+        XCTAssertEqual(apply(.userTappedRetry, to: .open), .open)
+    }
+
+    func test_open_avPlayerBeganPlaying_transitionsToPlaying() {
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: .open), .playing)
+    }
+
+    func test_open_avPlayerStalled_transitionsToPlayerRebuffering() {
+        XCTAssertEqual(apply(.avPlayerStalled, to: .open),
+                       .buffering(reason: .playerRebuffering))
+    }
+
+    func test_open_avPlayerResumed_idempotentOpen() {
+        XCTAssertEqual(apply(.avPlayerResumed, to: .open), .open)
+    }
+
+    func test_open_avPlayerFailed_transitionsToPlaybackFailed() {
+        XCTAssertEqual(apply(.avPlayerFailed, to: .open),
+                       .error(.playbackFailed))
+    }
+
+    func test_open_engineHealthStarving_transitionsToBufferingEngineStarving() {
+        XCTAssertEqual(apply(.engineHealthChanged(.starving), to: .open),
+                       .buffering(reason: .engineStarving))
+    }
+
+    func test_open_engineHealthNonStarving_idempotentOpen() {
+        XCTAssertEqual(apply(.engineHealthChanged(.healthy), to: .open), .open)
+        XCTAssertEqual(apply(.engineHealthChanged(.marginal), to: .open), .open)
+    }
+
+    func test_open_engineDisconnected_transitionsToError() {
+        XCTAssertEqual(apply(.engineDisconnected, to: .open),
+                       .error(.xpcDisconnected))
+    }
+
+    func test_open_engineReconnected_noAutoResumeStaysOpen() {
+        XCTAssertEqual(apply(.engineReconnected, to: .open), .open)
+    }
+
+    // MARK: - From .playing
+
+    func test_playing_userRequestedOpen_invariantStaysPlaying() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: .playing), .playing)
+    }
+
+    func test_playing_engineReturnedDescriptor_invariantStaysPlaying() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: .playing), .playing)
+    }
+
+    func test_playing_engineReturnedOpenError_invariantStaysPlaying() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: .playing), .playing)
+    }
+
+    func test_playing_userTappedPlay_idempotentPlaying() {
+        XCTAssertEqual(apply(.userTappedPlay, to: .playing), .playing)
+    }
+
+    func test_playing_userTappedPause_transitionsToPaused() {
+        XCTAssertEqual(apply(.userTappedPause, to: .playing), .paused)
+    }
+
+    func test_playing_userTappedClose_transitionsToClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: .playing), .closed)
+    }
+
+    func test_playing_userTappedRetry_invariantStaysPlaying() {
+        XCTAssertEqual(apply(.userTappedRetry, to: .playing), .playing)
+    }
+
+    func test_playing_avPlayerBeganPlaying_idempotentPlaying() {
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: .playing), .playing)
+    }
+
+    func test_playing_avPlayerStalled_transitionsToPlayerRebuffering() {
+        XCTAssertEqual(apply(.avPlayerStalled, to: .playing),
+                       .buffering(reason: .playerRebuffering))
+    }
+
+    func test_playing_avPlayerResumed_idempotentPlaying() {
+        XCTAssertEqual(apply(.avPlayerResumed, to: .playing), .playing)
+    }
+
+    func test_playing_avPlayerFailed_transitionsToPlaybackFailed() {
+        XCTAssertEqual(apply(.avPlayerFailed, to: .playing),
+                       .error(.playbackFailed))
+    }
+
+    func test_playing_engineHealthStarving_transitionsToBufferingEngineStarving() {
+        XCTAssertEqual(apply(.engineHealthChanged(.starving), to: .playing),
+                       .buffering(reason: .engineStarving))
+    }
+
+    func test_playing_engineHealthNonStarving_idempotentPlaying() {
+        XCTAssertEqual(apply(.engineHealthChanged(.healthy), to: .playing),
+                       .playing)
+        XCTAssertEqual(apply(.engineHealthChanged(.marginal), to: .playing),
+                       .playing)
+    }
+
+    func test_playing_engineDisconnected_transitionsToError() {
+        XCTAssertEqual(apply(.engineDisconnected, to: .playing),
+                       .error(.xpcDisconnected))
+    }
+
+    func test_playing_engineReconnected_noAutoResumeStaysPlaying() {
+        XCTAssertEqual(apply(.engineReconnected, to: .playing), .playing)
+    }
+
+    // MARK: - From .paused
+
+    func test_paused_userRequestedOpen_invariantStaysPaused() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: .paused), .paused)
+    }
+
+    func test_paused_engineReturnedDescriptor_invariantStaysPaused() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: .paused), .paused)
+    }
+
+    func test_paused_engineReturnedOpenError_invariantStaysPaused() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: .paused), .paused)
+    }
+
+    func test_paused_userTappedPlay_transitionsToPlaying() {
+        XCTAssertEqual(apply(.userTappedPlay, to: .paused), .playing)
+    }
+
+    func test_paused_userTappedPause_idempotentPaused() {
+        XCTAssertEqual(apply(.userTappedPause, to: .paused), .paused)
+    }
+
+    func test_paused_userTappedClose_transitionsToClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: .paused), .closed)
+    }
+
+    func test_paused_userTappedRetry_invariantStaysPaused() {
+        XCTAssertEqual(apply(.userTappedRetry, to: .paused), .paused)
+    }
+
+    func test_paused_avPlayerBeganPlaying_idempotentPaused() {
+        // Spurious AVPlayer rate during paused — no-op.
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: .paused), .paused)
+    }
+
+    func test_paused_avPlayerStalled_idempotentPaused() {
+        XCTAssertEqual(apply(.avPlayerStalled, to: .paused), .paused)
+    }
+
+    func test_paused_avPlayerResumed_idempotentPaused() {
+        XCTAssertEqual(apply(.avPlayerResumed, to: .paused), .paused)
+    }
+
+    func test_paused_avPlayerFailed_transitionsToPlaybackFailed() {
+        XCTAssertEqual(apply(.avPlayerFailed, to: .paused),
+                       .error(.playbackFailed))
+    }
+
+    func test_paused_engineHealthChanged_idempotentPaused() {
+        // Engine starvation suppressed while paused — health is HUD-visible
+        // but does not transition state.
+        for tier in StreamHealthTier.allCases {
+            XCTAssertEqual(apply(.engineHealthChanged(tier), to: .paused),
+                           .paused, "tier=\(tier)")
+        }
+    }
+
+    func test_paused_engineDisconnected_transitionsToError() {
+        XCTAssertEqual(apply(.engineDisconnected, to: .paused),
+                       .error(.xpcDisconnected))
+    }
+
+    func test_paused_engineReconnected_idempotentPaused() {
+        XCTAssertEqual(apply(.engineReconnected, to: .paused), .paused)
+    }
+
+    // MARK: - From .buffering(.openingStream)
+
+    private var bufOpen: PlayerState { .buffering(reason: .openingStream) }
+
+    func test_bufOpen_userRequestedOpen_idempotent() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: bufOpen), bufOpen)
+    }
+
+    func test_bufOpen_engineReturnedDescriptor_transitionsToOpen() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: bufOpen), .open)
+    }
+
+    func test_bufOpen_engineReturnedOpenError_transitionsToError() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: bufOpen),
+                       .error(.streamOpenFailed(.streamOpenFailed)))
+    }
+
+    func test_bufOpen_engineReturnedOpenError_carriesCode() {
+        // Different EngineErrorCode propagates correctly.
+        XCTAssertEqual(apply(.engineReturnedOpenError(.bookmarkInvalid),
+                             to: bufOpen),
+                       .error(.streamOpenFailed(.bookmarkInvalid)))
+    }
+
+    func test_bufOpen_userTappedPlay_invariant() {
+        XCTAssertEqual(apply(.userTappedPlay, to: bufOpen), bufOpen)
+    }
+
+    func test_bufOpen_userTappedPause_invariant() {
+        XCTAssertEqual(apply(.userTappedPause, to: bufOpen), bufOpen)
+    }
+
+    func test_bufOpen_userTappedClose_transitionsToClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: bufOpen), .closed)
+    }
+
+    func test_bufOpen_userTappedRetry_invariant() {
+        XCTAssertEqual(apply(.userTappedRetry, to: bufOpen), bufOpen)
+    }
+
+    func test_bufOpen_avPlayer_invariants() {
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: bufOpen), bufOpen)
+        XCTAssertEqual(apply(.avPlayerStalled, to: bufOpen), bufOpen)
+        XCTAssertEqual(apply(.avPlayerResumed, to: bufOpen), bufOpen)
+        XCTAssertEqual(apply(.avPlayerFailed, to: bufOpen), bufOpen)
+    }
+
+    func test_bufOpen_engineHealthChanged_idempotent() {
+        for tier in StreamHealthTier.allCases {
+            XCTAssertEqual(apply(.engineHealthChanged(tier), to: bufOpen),
+                           bufOpen, "tier=\(tier)")
+        }
+    }
+
+    func test_bufOpen_engineDisconnected_transitionsToError() {
+        XCTAssertEqual(apply(.engineDisconnected, to: bufOpen),
+                       .error(.xpcDisconnected))
+    }
+
+    func test_bufOpen_engineReconnected_staysBuffering() {
+        XCTAssertEqual(apply(.engineReconnected, to: bufOpen), bufOpen)
+    }
+
+    // MARK: - From .buffering(.engineStarving)
+
+    private var bufEngine: PlayerState { .buffering(reason: .engineStarving) }
+
+    func test_bufEngine_userRequestedOpen_invariant() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: bufEngine), bufEngine)
+    }
+
+    func test_bufEngine_engineReturnedDescriptor_invariant() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: bufEngine), bufEngine)
+    }
+
+    func test_bufEngine_engineReturnedOpenError_invariant() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: bufEngine), bufEngine)
+    }
+
+    func test_bufEngine_userTappedPlay_idempotent() {
+        XCTAssertEqual(apply(.userTappedPlay, to: bufEngine), bufEngine)
+    }
+
+    func test_bufEngine_userTappedPause_transitionsToPaused() {
+        XCTAssertEqual(apply(.userTappedPause, to: bufEngine), .paused)
+    }
+
+    func test_bufEngine_userTappedClose_transitionsToClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: bufEngine), .closed)
+    }
+
+    func test_bufEngine_userTappedRetry_invariant() {
+        XCTAssertEqual(apply(.userTappedRetry, to: bufEngine), bufEngine)
+    }
+
+    func test_bufEngine_avPlayerBeganPlaying_raceAcceptToPlaying() {
+        // AVPlayer began before engine sent the recovered tier — accept.
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: bufEngine), .playing)
+    }
+
+    func test_bufEngine_avPlayerStalled_swapsToPlayerRebuffering() {
+        XCTAssertEqual(apply(.avPlayerStalled, to: bufEngine),
+                       .buffering(reason: .playerRebuffering))
+    }
+
+    func test_bufEngine_avPlayerResumed_idempotent() {
+        XCTAssertEqual(apply(.avPlayerResumed, to: bufEngine), bufEngine)
+    }
+
+    func test_bufEngine_avPlayerFailed_transitionsToPlaybackFailed() {
+        XCTAssertEqual(apply(.avPlayerFailed, to: bufEngine),
+                       .error(.playbackFailed))
+    }
+
+    func test_bufEngine_engineHealthStarving_idempotent() {
+        XCTAssertEqual(apply(.engineHealthChanged(.starving), to: bufEngine),
+                       bufEngine)
+    }
+
+    func test_bufEngine_engineHealthRecovered_transitionsToPlaying() {
+        XCTAssertEqual(apply(.engineHealthChanged(.healthy), to: bufEngine),
+                       .playing)
+        XCTAssertEqual(apply(.engineHealthChanged(.marginal), to: bufEngine),
+                       .playing)
+    }
+
+    func test_bufEngine_engineDisconnected_transitionsToError() {
+        XCTAssertEqual(apply(.engineDisconnected, to: bufEngine),
+                       .error(.xpcDisconnected))
+    }
+
+    func test_bufEngine_engineReconnected_staysBuffering() {
+        XCTAssertEqual(apply(.engineReconnected, to: bufEngine), bufEngine)
+    }
+
+    // MARK: - From .buffering(.playerRebuffering)
+
+    private var bufPlayer: PlayerState {
+        .buffering(reason: .playerRebuffering)
+    }
+
+    func test_bufPlayer_userRequestedOpen_invariant() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: bufPlayer), bufPlayer)
+    }
+
+    func test_bufPlayer_engineReturnedDescriptor_invariant() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: bufPlayer),
+                       bufPlayer)
+    }
+
+    func test_bufPlayer_engineReturnedOpenError_invariant() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: bufPlayer), bufPlayer)
+    }
+
+    func test_bufPlayer_userTappedPlay_idempotent() {
+        XCTAssertEqual(apply(.userTappedPlay, to: bufPlayer), bufPlayer)
+    }
+
+    func test_bufPlayer_userTappedPause_transitionsToPaused() {
+        XCTAssertEqual(apply(.userTappedPause, to: bufPlayer), .paused)
+    }
+
+    func test_bufPlayer_userTappedClose_transitionsToClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: bufPlayer), .closed)
+    }
+
+    func test_bufPlayer_userTappedRetry_invariant() {
+        XCTAssertEqual(apply(.userTappedRetry, to: bufPlayer), bufPlayer)
+    }
+
+    func test_bufPlayer_avPlayerBeganPlaying_transitionsToPlaying() {
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: bufPlayer), .playing)
+    }
+
+    func test_bufPlayer_avPlayerStalled_idempotent() {
+        XCTAssertEqual(apply(.avPlayerStalled, to: bufPlayer), bufPlayer)
+    }
+
+    func test_bufPlayer_avPlayerResumed_transitionsToPlaying() {
+        XCTAssertEqual(apply(.avPlayerResumed, to: bufPlayer), .playing)
+    }
+
+    func test_bufPlayer_avPlayerFailed_transitionsToPlaybackFailed() {
+        XCTAssertEqual(apply(.avPlayerFailed, to: bufPlayer),
+                       .error(.playbackFailed))
+    }
+
+    func test_bufPlayer_engineHealthStarving_swapsToEngineStarving() {
+        // Engine wins precedence; reason swap.
+        XCTAssertEqual(apply(.engineHealthChanged(.starving), to: bufPlayer),
+                       .buffering(reason: .engineStarving))
+    }
+
+    func test_bufPlayer_engineHealthNonStarving_stays() {
+        XCTAssertEqual(apply(.engineHealthChanged(.healthy), to: bufPlayer),
+                       bufPlayer)
+        XCTAssertEqual(apply(.engineHealthChanged(.marginal), to: bufPlayer),
+                       bufPlayer)
+    }
+
+    func test_bufPlayer_engineDisconnected_transitionsToError() {
+        XCTAssertEqual(apply(.engineDisconnected, to: bufPlayer),
+                       .error(.xpcDisconnected))
+    }
+
+    func test_bufPlayer_engineReconnected_staysBuffering() {
+        XCTAssertEqual(apply(.engineReconnected, to: bufPlayer), bufPlayer)
+    }
+
+    // MARK: - From .error(_)
+
+    private var errDisc: PlayerState { .error(.xpcDisconnected) }
+    private var errFail: PlayerState {
+        .error(.streamOpenFailed(.streamOpenFailed))
+    }
+    private var errPlay: PlayerState { .error(.playbackFailed) }
+
+    func test_error_userRequestedOpen_invariant() {
+        XCTAssertEqual(apply(.userRequestedOpen, to: errDisc), errDisc)
+    }
+
+    func test_error_engineReturnedDescriptor_invariant() {
+        XCTAssertEqual(apply(.engineReturnedDescriptor, to: errDisc), errDisc)
+    }
+
+    func test_error_engineReturnedOpenError_invariant() {
+        XCTAssertEqual(apply(.engineReturnedOpenError(.streamOpenFailed),
+                             to: errDisc), errDisc)
+    }
+
+    func test_error_userTappedPlay_invariant() {
+        XCTAssertEqual(apply(.userTappedPlay, to: errDisc), errDisc)
+    }
+
+    func test_error_userTappedPause_invariant() {
+        XCTAssertEqual(apply(.userTappedPause, to: errDisc), errDisc)
+    }
+
+    func test_error_userTappedClose_transitionsToClosed() {
+        XCTAssertEqual(apply(.userTappedClose, to: errDisc), .closed)
+        XCTAssertEqual(apply(.userTappedClose, to: errFail), .closed)
+        XCTAssertEqual(apply(.userTappedClose, to: errPlay), .closed)
+    }
+
+    func test_error_userTappedRetry_transitionsToBufferingOpeningStream() {
+        XCTAssertEqual(apply(.userTappedRetry, to: errDisc),
+                       .buffering(reason: .openingStream))
+        XCTAssertEqual(apply(.userTappedRetry, to: errFail),
+                       .buffering(reason: .openingStream))
+        XCTAssertEqual(apply(.userTappedRetry, to: errPlay),
+                       .buffering(reason: .openingStream))
+    }
+
+    func test_error_avPlayer_invariants() {
+        XCTAssertEqual(apply(.avPlayerBeganPlaying, to: errDisc), errDisc)
+        XCTAssertEqual(apply(.avPlayerStalled, to: errDisc), errDisc)
+        XCTAssertEqual(apply(.avPlayerResumed, to: errDisc), errDisc)
+        XCTAssertEqual(apply(.avPlayerFailed, to: errDisc), errDisc)
+    }
+
+    func test_error_engineHealthChanged_idempotent() {
+        for tier in StreamHealthTier.allCases {
+            XCTAssertEqual(apply(.engineHealthChanged(tier), to: errDisc),
+                           errDisc, "tier=\(tier)")
+        }
+    }
+
+    func test_error_engineDisconnected_idempotent() {
+        XCTAssertEqual(apply(.engineDisconnected, to: errDisc), errDisc)
+    }
+
+    func test_error_engineReconnected_noAutoResume() {
+        // Per design § D6 — reconnect does not auto-recover.
+        XCTAssertEqual(apply(.engineReconnected, to: errDisc), errDisc)
+    }
+
+    // MARK: - Determinism
+
+    func test_determinism_replayProducesSameTrajectory() {
+        // A canonical "open → play → stall → recover → close" trajectory.
+        let events: [PlayerEvent] = [
+            .userRequestedOpen,
+            .engineReturnedDescriptor,
+            .userTappedPlay,
+            .avPlayerBeganPlaying,
+            .avPlayerStalled,
+            .avPlayerResumed,
+            .userTappedClose
+        ]
+
+        func play() -> [PlayerState] {
+            var s: PlayerState = .closed
+            var trajectory: [PlayerState] = [s]
+            for e in events {
+                s = PlayerStateMachine.apply(e, to: s, now: now)
+                trajectory.append(s)
+            }
+            return trajectory
+        }
+
+        let first = play()
+        let second = play()
+        XCTAssertEqual(first, second)
+
+        // Spot-check a few key transitions.
+        XCTAssertEqual(first[1], .buffering(reason: .openingStream),
+                       "after userRequestedOpen")
+        XCTAssertEqual(first[2], .open, "after engineReturnedDescriptor")
+        XCTAssertEqual(first[3], .playing, "after userTappedPlay")
+        XCTAssertEqual(first[5], .buffering(reason: .playerRebuffering),
+                       "after avPlayerStalled")
+        XCTAssertEqual(first[6], .playing, "after avPlayerResumed")
+        XCTAssertEqual(first[7], .closed, "after userTappedClose")
+    }
+}

--- a/Tests/ButterBarTests/PlayerHUDSnapshotTests.swift
+++ b/Tests/ButterBarTests/PlayerHUDSnapshotTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import AppKit
 import SnapshotTesting
 import EngineInterface
+import PlayerDomain
 @testable import ButterBar
 
 // Render a SwiftUI view at a fixed size for macOS snapshot capture.
@@ -228,6 +229,47 @@ final class PlayerViewModelReconnectTests: XCTestCase {
             try await Task.sleep(for: poll)
         }
         XCTFail("Timed out: \(message)")
+    }
+
+    // MARK: - State projection (Phase 3 #18)
+
+    /// Verifies the engine-event projection wired in Phase 3: a starving
+    /// health DTO routes through `PlayerStateMachine` and surfaces as
+    /// `state == .buffering(.engineStarving)`. The existing reconnect tests
+    /// already cover the underlying delivery path; this asserts the new
+    /// projection contract added by the Phase 3 refactor.
+    func testStateBecomesBufferingEngineStarvingOnStarvingHealth() async throws {
+        let engineClient = EngineClient()
+        let streamID = "stream-projection-1"
+        let descriptor = StreamDescriptorDTO(
+            streamID: streamID as NSString,
+            loopbackURL: "http://127.0.0.1:52101/stream/\(streamID)" as NSString,
+            contentType: "video/mp4",
+            contentLength: 10_000
+        )
+        let viewModel = PlayerViewModel(streamDescriptor: descriptor,
+                                        engineClient: engineClient)
+
+        let handler = EngineEventHandler()
+        await engineClient._replaceEventHandlerForTesting(handler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        handler.streamHealthChanged(
+            StreamHealthDTO(
+                streamID: streamID as NSString,
+                secondsBufferedAhead: 1,
+                downloadRateBytesPerSec: 50_000,
+                requiredBitrateBytesPerSec: nil,
+                peerCount: 0,
+                outstandingCriticalPieces: 5,
+                recentStallCount: 3,
+                tier: "starving"
+            )
+        )
+
+        try await assertEventually("state should project to .buffering(.engineStarving)") {
+            viewModel.state == .buffering(reason: .engineStarving)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3 foundation per [`docs/design/player-state-foundation.md`](../blob/main/docs/design/player-state-foundation.md).

Closes #18. Refs #3.

## What this PR contains

- **`Packages/PlayerDomain`** — new pure-Swift package mirroring the Phase 1/2 `LibraryDomain` / `SubtitleDomain` pattern. Contains `PlayerState`, `BufferingReason`, `PlayerError`, `PlayerEvent`, `PlayerStateMachine`.
- **112 transition-matrix tests** covering every cell in design § Transition matrix (8 states × 14 events). All pass.
- **CI** runs the new package alongside the existing pure-Swift packages.
- **`EngineErrorCode` marked `Sendable`** — required so `PlayerError.streamOpenFailed(EngineErrorCode)` can be `Sendable`. Genuinely sendable: immutable `Int` enum.
- **`PlayerViewModel` refactored** to publish `state: PlayerState` driven through `PlayerStateMachine.apply`. Engine-event projection + AVPlayer KVO wired per design § Engine-event projection rules. Existing `health: StreamHealthDTO?` surface preserved for the HUD (which renders fields the state machine deliberately doesn't carry).
- **`PlayerView`** updated: error chrome derives from `state` instead of the removed `error: String?`. Minimal interim copy; #26 will replace with brand-voice + retry chrome.
- **`.pbxproj` wired** for the new package, mirroring the LibraryDomain pattern.
- **`testStateBecomesBufferingEngineStarvingOnStarvingHealth`** integration test proves the projection end-to-end through a real `EngineClient`.

## Verification

- ✅ Swift package tests: 112/112 pass.
- ✅ Xcode build: green.
- ✅ `PlayerHUDSnapshotTests` (6 cases): pass — no visual regression.
- ✅ `PlayerViewModelReconnectTests` (2 cases) + new state-projection case (3rd case): all pass.

## Slight deviation from design doc

Design D4 said the types live in `App/Features/Player/`. They actually live in `Packages/PlayerDomain` to match the Phase 1/2 pattern and to get fast Swift-package CI (Xcode tests are advisory; package tests are required gates). Functionally equivalent — the types are still app-side, still consumed by `PlayerViewModel`.

## Out of scope (per design doc § Out of scope)

- Resume prompt UI — that is **#19**.
- Subtitle / audio picker chrome — those are **#22** / **#23**.
- Player chrome / overlay controls — that is **#24**.
- Error state copy and retry button placement — that is **#26**.
- Engine-initiated stream close (design § Open questions O1) — recorded as gap; not addressed here.
- Episode-aware logic — Phase 3 tail (#20 / #21) per Option A.

## Coordination note

Two parallel sessions are active in sibling worktrees on Phase 1 #35 and Phase 2 app integration. Confirmed no overlap with their surfaces; `.pbxproj` edits are cleanly separable (different LibraryDomain vs new PlayerDomain entries).