### PR TITLE
feat(metadata): MetadataDomain foundation (epic #2 phase 4, #11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           swift test --package-path Packages/LibraryDomain
           swift test --package-path Packages/SubtitleDomain
           swift test --package-path Packages/PlayerDomain
+          swift test --package-path Packages/MetadataDomain
 
       - name: Snapshot tests (advisory — pixel drift on CI vs local)
         # CI runners don't have the owner's personal signing certificate for

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ xcuserdata/
 .LSOverride
 default.profraw
 *.profraw
+
+# Local secrets — never commit. Template lives at TMDBSecrets.local.swift.example.
+**/TMDBSecrets.local.swift

--- a/Packages/MetadataDomain/Package.swift
+++ b/Packages/MetadataDomain/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "MetadataDomain",
+    platforms: [
+        .macOS(.v26)
+    ],
+    products: [
+        .library(name: "MetadataDomain", targets: ["MetadataDomain"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "MetadataDomain",
+            dependencies: [],
+            path: "Sources/MetadataDomain",
+            exclude: ["TMDBSecrets.local.swift.example"]
+        ),
+        .testTarget(
+            name: "MetadataDomainTests",
+            dependencies: ["MetadataDomain"],
+            path: "Tests/MetadataDomainTests",
+            resources: [
+                .copy("Fixtures")
+            ]
+        )
+    ]
+)

--- a/Packages/MetadataDomain/Sources/MetadataDomain/Episode.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/Episode.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct Episode: Equatable, Sendable, Hashable, Codable {
+    /// Distinct TMDB ID per episode.
+    public let id: MediaID
+    public let showID: MediaID
+    public let seasonNumber: Int
+    public let episodeNumber: Int
+    public let name: String
+    public let overview: String
+    public let stillPath: String?
+    public let runtimeMinutes: Int?
+    public let airDate: Date?
+
+    public init(id: MediaID,
+                showID: MediaID,
+                seasonNumber: Int,
+                episodeNumber: Int,
+                name: String,
+                overview: String,
+                stillPath: String?,
+                runtimeMinutes: Int?,
+                airDate: Date?) {
+        self.id = id
+        self.showID = showID
+        self.seasonNumber = seasonNumber
+        self.episodeNumber = episodeNumber
+        self.name = name
+        self.overview = overview
+        self.stillPath = stillPath
+        self.runtimeMinutes = runtimeMinutes
+        self.airDate = airDate
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/Genre.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/Genre.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct Genre: Equatable, Sendable, Hashable, Codable {
+    public let id: Int
+    public let name: String
+
+    public init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/ImageCache.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/ImageCache.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// `URLCache`-backed image fetcher. No third-party image library; everything
+/// goes through `URLSession` with a custom `URLCache` configured against a
+/// 500 MB disk budget under `metadata/images/`.
+///
+/// Failure mode: callers receive a typed error, never a broken image; the
+/// SwiftUI consumer renders a brand-tokenized placeholder. Placeholder
+/// rendering itself is UI-side; this layer is concerned only with bytes.
+public final class ImageCache: @unchecked Sendable {
+
+    public let urlCache: URLCache
+    public let session: URLSession
+    public let diskPath: URL
+
+    public init(baseDirectory: URL) throws {
+        let dir = baseDirectory.appendingPathComponent(ImageCacheConfig.directoryName,
+                                                       isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        self.diskPath = dir
+        self.urlCache = URLCache(
+            memoryCapacity: ImageCacheConfig.memoryCapacityBytes,
+            diskCapacity: ImageCacheConfig.diskCapacityBytes,
+            directory: dir
+        )
+        let config = URLSessionConfiguration.default
+        config.urlCache = urlCache
+        config.requestCachePolicy = .useProtocolCachePolicy
+        self.session = URLSession(configuration: config)
+    }
+
+    public enum Failure: Error, Equatable, Sendable {
+        case transport
+        case http(Int)
+        case empty
+    }
+
+    /// Fetch image bytes. Cached at the `URLCache` layer.
+    public func data(for url: URL) async -> Result<Data, Failure> {
+        do {
+            let (data, response) = try await session.data(from: url)
+            if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+                return .failure(.http(http.statusCode))
+            }
+            if data.isEmpty {
+                return .failure(.empty)
+            }
+            return .success(data)
+        } catch {
+            return .failure(.transport)
+        }
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/JaroWinkler.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/JaroWinkler.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Jaro-Winkler string similarity. Pure, deterministic, no I/O.
+/// Used by `MatchRanker` to score parsed-title vs candidate-title pairs.
+/// Returns a value in `[0, 1]`; 1 = exact match.
+enum JaroWinkler {
+
+    static func similarity(_ a: String, _ b: String) -> Double {
+        let s1 = Array(a)
+        let s2 = Array(b)
+        if s1.isEmpty && s2.isEmpty { return 1.0 }
+        if s1.isEmpty || s2.isEmpty { return 0.0 }
+
+        let jaro = jaroSimilarity(s1, s2)
+        if jaro < 0.7 { return jaro }
+
+        // Common-prefix bonus, capped at 4 chars.
+        var prefix = 0
+        for i in 0..<min(4, min(s1.count, s2.count)) {
+            if s1[i] == s2[i] { prefix += 1 } else { break }
+        }
+        return jaro + Double(prefix) * 0.1 * (1 - jaro)
+    }
+
+    private static func jaroSimilarity(_ s1: [Character], _ s2: [Character]) -> Double {
+        let len1 = s1.count
+        let len2 = s2.count
+        let matchDistance = max(len1, len2) / 2 - 1
+        var s1Matches = [Bool](repeating: false, count: len1)
+        var s2Matches = [Bool](repeating: false, count: len2)
+
+        var matches = 0
+        for i in 0..<len1 {
+            let start = max(0, i - matchDistance)
+            let end = min(i + matchDistance + 1, len2)
+            if start >= end { continue }
+            for j in start..<end where !s2Matches[j] && s1[i] == s2[j] {
+                s1Matches[i] = true
+                s2Matches[j] = true
+                matches += 1
+                break
+            }
+        }
+        if matches == 0 { return 0.0 }
+
+        var transpositions = 0
+        var k = 0
+        for i in 0..<len1 where s1Matches[i] {
+            while !s2Matches[k] { k += 1 }
+            if s1[i] != s2[k] { transpositions += 1 }
+            k += 1
+        }
+        let m = Double(matches)
+        return (m / Double(len1) +
+                m / Double(len2) +
+                (m - Double(transpositions) / 2.0) / m) / 3.0
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/MatchRanker.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/MatchRanker.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+public struct RankedMatch: Equatable, Sendable {
+    public let item: MediaItem
+    /// Confidence in `[0, 1]`. 1 = perfect match.
+    public let confidence: Double
+    /// Human-readable reasons for debug + telemetry.
+    public let reasons: [String]
+
+    public init(item: MediaItem, confidence: Double, reasons: [String]) {
+        self.item = item
+        self.confidence = confidence
+        self.reasons = reasons
+    }
+}
+
+/// Pure ranker that scores a `[MediaItem]` candidate list against a
+/// `ParsedTitle`. Title similarity uses Jaro-Winkler; year matches with a
+/// `±1` tolerance (trailers and re-releases drift); shows are bonused when
+/// the parsed input also has a season/episode marker.
+///
+/// The default minimum confidence threshold callers should require is
+/// `MatchRanker.defaultThreshold` (`0.6`).
+public enum MatchRanker {
+
+    public static let defaultThreshold: Double = 0.6
+
+    public static func rank(parsed: ParsedTitle,
+                            candidates: [MediaItem]) -> [RankedMatch] {
+        let parsedTitleNorm = normalise(parsed.title)
+        return candidates.map { item in
+            score(parsed: parsed,
+                  parsedTitleNorm: parsedTitleNorm,
+                  candidate: item)
+        }.sorted { $0.confidence > $1.confidence }
+    }
+
+    // MARK: - Scoring
+
+    private static func score(parsed: ParsedTitle,
+                              parsedTitleNorm: String,
+                              candidate: MediaItem) -> RankedMatch {
+        let candidateTitle: String
+        let candidateYear: Int?
+        let candidateIsShow: Bool
+        switch candidate {
+        case .movie(let m):
+            candidateTitle = m.title
+            candidateYear = m.releaseYear
+            candidateIsShow = false
+        case .show(let s):
+            candidateTitle = s.name
+            candidateYear = s.firstAirYear
+            candidateIsShow = true
+        }
+
+        var reasons: [String] = []
+
+        // 1. Title similarity (Jaro-Winkler over normalised forms).
+        let titleSim = JaroWinkler.similarity(parsedTitleNorm, normalise(candidateTitle))
+        reasons.append(String(format: "title-sim=%.2f", titleSim))
+
+        // 2. Year score: exact = 1.0, ±1 = 0.85, ±2 = 0.5, else 0.
+        var yearScore: Double = 0.5  // neutral when we don't know
+        if let py = parsed.year, let cy = candidateYear {
+            let delta = abs(py - cy)
+            switch delta {
+            case 0:
+                yearScore = 1.0
+                reasons.append("year=exact(\(cy))")
+            case 1:
+                yearScore = 0.85
+                reasons.append("year=±1(\(cy)≈\(py))")
+            case 2:
+                yearScore = 0.5
+                reasons.append("year=±2(\(cy)≈\(py))")
+            default:
+                yearScore = 0.0
+                reasons.append("year=miss(\(cy)≠\(py))")
+            }
+        } else if parsed.year != nil && candidateYear == nil {
+            yearScore = 0.4   // candidate has no year info; mild demotion
+            reasons.append("year=candidate-unknown")
+        } else if parsed.year == nil {
+            yearScore = 0.6   // no signal; don't penalise too hard
+            reasons.append("year=parsed-unknown")
+        }
+
+        // 3. Episode-shape match: parsed has S/E and candidate is a Show, or
+        // parsed has no S/E and candidate is a Movie.
+        let parsedIsShowShape = parsed.season != nil || parsed.episode != nil
+        var shapeScore: Double = 0.5
+        if parsedIsShowShape && candidateIsShow {
+            shapeScore = 1.0
+            reasons.append("shape=show↔show")
+        } else if !parsedIsShowShape && !candidateIsShow {
+            shapeScore = 1.0
+            reasons.append("shape=movie↔movie")
+        } else if parsedIsShowShape && !candidateIsShow {
+            shapeScore = 0.1
+            reasons.append("shape=show-vs-movie")
+        } else {
+            // parsed is movie-shape, candidate is show — possible (anime
+            // releases without S/E markers); mild demotion only.
+            shapeScore = 0.4
+            reasons.append("shape=movie-vs-show")
+        }
+
+        // Weighted combination. Title carries most of the signal; year and
+        // shape are gates more than they are scores.
+        let confidence = (titleSim * 0.65) + (yearScore * 0.20) + (shapeScore * 0.15)
+
+        return RankedMatch(item: candidate,
+                           confidence: confidence,
+                           reasons: reasons)
+    }
+
+    // MARK: - Normalisation
+
+    /// Lowercase, strip punctuation, collapse whitespace. Keeps Roman
+    /// numerals as-is so that `Rocky II` ≠ `Rocky 2`.
+    static func normalise(_ s: String) -> String {
+        let lowered = s.lowercased()
+        var stripped = ""
+        stripped.reserveCapacity(lowered.count)
+        for ch in lowered {
+            if ch.isLetter || ch.isNumber || ch == " " {
+                stripped.append(ch)
+            } else {
+                stripped.append(" ")
+            }
+        }
+        // Collapse runs of whitespace.
+        let collapsed = stripped
+            .split(whereSeparator: { $0 == " " })
+            .joined(separator: " ")
+        return collapsed
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/MediaID.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/MediaID.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Stable identifier for a metadata entity (movie, show, season, episode).
+///
+/// Wraps a `(provider, id)` pair so v1.5+ can introduce additional providers
+/// (`.imdb`, `.tvdb`, `.fanart`) without migrating cached data — the
+/// `provider` discriminator silently invalidates entries that don't carry it.
+public struct MediaID: Equatable, Sendable, Hashable, Codable {
+    public let provider: Provider
+    public let id: Int64
+
+    public init(provider: Provider, id: Int64) {
+        self.provider = provider
+        self.id = id
+    }
+
+    public enum Provider: String, Sendable, Codable, Hashable, Equatable {
+        case tmdb
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/MediaItem.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/MediaItem.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Discriminated union over the two top-level metadata entities. Every
+/// browse row, detail view, search result, and continue-watching projection
+/// ranges over `[MediaItem]`. Codable round-trips cleanly via Swift's
+/// automatic synthesis on enums with associated values.
+public enum MediaItem: Equatable, Sendable, Hashable, Codable {
+    case movie(Movie)
+    case show(Show)
+
+    public var id: MediaID {
+        switch self {
+        case .movie(let m): return m.id
+        case .show(let s): return s.id
+        }
+    }
+}
+
+public enum TrendingMedia: String, Sendable, Equatable, Hashable, Codable {
+    case movie
+    case tv
+    case all
+}
+
+public enum TrendingWindow: String, Sendable, Equatable, Hashable, Codable {
+    case day
+    case week
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/MetadataCache.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/MetadataCache.swift
@@ -1,0 +1,233 @@
+import Foundation
+
+/// Per-entry sidecar metadata stored alongside a cached response. Persisted
+/// to `cache_meta.json` (one map keyed by canonical URL) so a single read
+/// hydrates the entire TTL/ETag table.
+public struct MetadataCacheEntryMeta: Equatable, Sendable, Codable {
+    public let etag: String?
+    public let lastModified: String?
+    /// Wall-clock instant the response was first written.
+    public let fetchedAt: Date
+    /// Wall-clock instant past which the entry is stale.
+    public let expiresAt: Date
+
+    public init(etag: String?,
+                lastModified: String?,
+                fetchedAt: Date,
+                expiresAt: Date) {
+        self.etag = etag
+        self.lastModified = lastModified
+        self.fetchedAt = fetchedAt
+        self.expiresAt = expiresAt
+    }
+}
+
+/// Lookup result for a cache hit.
+public struct MetadataCacheHit: Equatable, Sendable {
+    public enum Freshness: Sendable, Equatable { case fresh, stale }
+    public let data: Data
+    public let freshness: Freshness
+    public let meta: MetadataCacheEntryMeta
+}
+
+/// Injectable wall-clock; tests substitute a fixed-time clock. Pure layer
+/// over `Date()`; nothing else relies on `Date.init`.
+public struct CacheClock: Sendable {
+    public var now: @Sendable () -> Date
+    public init(now: @escaping @Sendable () -> Date) { self.now = now }
+    public static let system = CacheClock(now: { Date() })
+}
+
+/// On-disk JSON cache for TMDB responses. Atomic writes (via `.tmp` + rename),
+/// corrupt-read fallback, ETag/Last-Modified round-trip. The cache itself
+/// does not perform network I/O — callers consult it before a fetch and
+/// write the response back after.
+///
+/// Stale-while-revalidate flow:
+///   1. `lookup(url:)` → `.stale(...)` ⇒ caller renders the stale data
+///      immediately, kicks off a background fetch, and `store(...)`s the
+///      fresh result when ready.
+///   2. `lookup(url:)` → `.fresh(...)` ⇒ caller renders directly; no fetch.
+///   3. Miss ⇒ caller fetches, then `store(...)`s.
+public final class MetadataCache: @unchecked Sendable {
+    public let baseDirectory: URL
+    private let responsesDirectory: URL
+    private let metaURL: URL
+    private let clock: CacheClock
+    private let lock = NSLock()
+    private var meta: [String: MetadataCacheEntryMeta]
+
+    /// Standard sandbox path: `~/Library/Application Support/ButterBar/metadata/`.
+    public static func defaultBaseDirectory() throws -> URL {
+        let fm = FileManager.default
+        let appSupport = try fm.url(for: .applicationSupportDirectory,
+                                    in: .userDomainMask,
+                                    appropriateFor: nil,
+                                    create: true)
+        return appSupport.appendingPathComponent("ButterBar/metadata", isDirectory: true)
+    }
+
+    public init(baseDirectory: URL,
+                clock: CacheClock = .system) throws {
+        self.baseDirectory = baseDirectory
+        self.responsesDirectory = baseDirectory.appendingPathComponent("responses", isDirectory: true)
+        self.metaURL = baseDirectory.appendingPathComponent("cache_meta.json")
+        self.clock = clock
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: responsesDirectory, withIntermediateDirectories: true)
+
+        if let data = try? Data(contentsOf: metaURL),
+           let parsed = try? JSONDecoder.iso8601.decode([String: MetadataCacheEntryMeta].self, from: data) {
+            self.meta = parsed
+        } else {
+            self.meta = [:]
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Inspect the cache without touching the network. A return of `nil`
+    /// means "miss"; callers should fetch + store. A `.stale` return is
+    /// usable but the caller should kick off a background refresh.
+    public func lookup(url: URL) -> MetadataCacheHit? {
+        lock.lock(); defer { lock.unlock() }
+        let key = canonicalKey(for: url)
+        guard let entryMeta = meta[key] else { return nil }
+        let path = responseFile(for: key)
+        guard let data = try? Data(contentsOf: path) else {
+            // Corrupt or missing payload; treat as miss.
+            meta.removeValue(forKey: key)
+            try? FileManager.default.removeItem(at: path)
+            persistMetaLocked()
+            return nil
+        }
+        // Validate JSON structure on read so a half-written file doesn't
+        // poison downstream decoding. The cache itself is JSON-shape-agnostic
+        // beyond "must parse"; concrete decoding happens in callers.
+        guard (try? JSONSerialization.jsonObject(with: data)) != nil else {
+            meta.removeValue(forKey: key)
+            try? FileManager.default.removeItem(at: path)
+            persistMetaLocked()
+            return nil
+        }
+        let now = clock.now()
+        let freshness: MetadataCacheHit.Freshness = (entryMeta.expiresAt > now) ? .fresh : .stale
+        return MetadataCacheHit(data: data, freshness: freshness, meta: entryMeta)
+    }
+
+    /// Store (or overwrite) a cache entry. Atomic write via `.tmp` + rename.
+    public func store(url: URL,
+                      data: Data,
+                      ttl: TimeInterval,
+                      etag: String? = nil,
+                      lastModified: String? = nil) throws {
+        lock.lock(); defer { lock.unlock() }
+        let key = canonicalKey(for: url)
+        let path = responseFile(for: key)
+        let tmp = path.appendingPathExtension("tmp")
+        try data.write(to: tmp, options: .atomic)
+        // Replace if exists; rename is atomic on the same volume.
+        if FileManager.default.fileExists(atPath: path.path) {
+            _ = try FileManager.default.replaceItemAt(path, withItemAt: tmp)
+        } else {
+            try FileManager.default.moveItem(at: tmp, to: path)
+        }
+        let now = clock.now()
+        meta[key] = MetadataCacheEntryMeta(
+            etag: etag,
+            lastModified: lastModified,
+            fetchedAt: now,
+            expiresAt: now.addingTimeInterval(max(0, ttl))
+        )
+        persistMetaLocked()
+    }
+
+    /// Update sidecar TTL/ETag without rewriting the payload — for `304 Not
+    /// Modified` responses where the body is unchanged.
+    public func touch(url: URL,
+                      ttl: TimeInterval,
+                      etag: String? = nil,
+                      lastModified: String? = nil) {
+        lock.lock(); defer { lock.unlock() }
+        let key = canonicalKey(for: url)
+        guard meta[key] != nil else { return }
+        let now = clock.now()
+        meta[key] = MetadataCacheEntryMeta(
+            etag: etag ?? meta[key]?.etag,
+            lastModified: lastModified ?? meta[key]?.lastModified,
+            fetchedAt: now,
+            expiresAt: now.addingTimeInterval(max(0, ttl))
+        )
+        persistMetaLocked()
+    }
+
+    public func remove(url: URL) {
+        lock.lock(); defer { lock.unlock() }
+        let key = canonicalKey(for: url)
+        meta.removeValue(forKey: key)
+        try? FileManager.default.removeItem(at: responseFile(for: key))
+        persistMetaLocked()
+    }
+
+    public func clearAll() throws {
+        lock.lock(); defer { lock.unlock() }
+        meta.removeAll()
+        try? FileManager.default.removeItem(at: responsesDirectory)
+        try FileManager.default.createDirectory(at: responsesDirectory,
+                                                withIntermediateDirectories: true)
+        persistMetaLocked()
+    }
+
+    // MARK: - Internals
+
+    private func responseFile(for key: String) -> URL {
+        responsesDirectory.appendingPathComponent("\(key).json")
+    }
+
+    /// Canonical key: SHA-style stable hash of URL.absoluteString. We use a
+    /// hex digest of the host + path + query to keep filenames safe across
+    /// macOS file systems (no slashes, no colons).
+    private func canonicalKey(for url: URL) -> String {
+        let s = url.absoluteString
+        // Lightweight FNV-1a 64-bit hash. Collisions across the few hundred
+        // URLs the app sees are vanishingly unlikely; we don't need crypto.
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in s.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return String(format: "%016x", hash)
+    }
+
+    private func persistMetaLocked() {
+        guard let data = try? JSONEncoder.iso8601.encode(meta) else { return }
+        let tmp = metaURL.appendingPathExtension("tmp")
+        do {
+            try data.write(to: tmp, options: .atomic)
+            if FileManager.default.fileExists(atPath: metaURL.path) {
+                _ = try FileManager.default.replaceItemAt(metaURL, withItemAt: tmp)
+            } else {
+                try FileManager.default.moveItem(at: tmp, to: metaURL)
+            }
+        } catch {
+            // Persistence failure is non-fatal — the next write retries.
+        }
+    }
+}
+
+extension JSONEncoder {
+    static var iso8601: JSONEncoder {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }
+}
+
+extension JSONDecoder {
+    static var iso8601: JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/MetadataCacheTTL.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/MetadataCacheTTL.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Single-source TTL constants for the metadata cache.
+/// Tunable, but intentionally co-located so refresh intervals don't drift
+/// across the codebase. See design § D7.
+public enum MetadataCacheTTL {
+    public static let trendingWeek: TimeInterval = 6 * 60 * 60          // 6 h
+    public static let trendingDay: TimeInterval = 1 * 60 * 60           // 1 h
+    public static let popular: TimeInterval = 24 * 60 * 60              // 24 h
+    public static let topRated: TimeInterval = 7 * 24 * 60 * 60         // 7 d
+    public static let movieDetail: TimeInterval = 7 * 24 * 60 * 60      // 7 d
+    public static let showDetail: TimeInterval = 7 * 24 * 60 * 60       // 7 d
+    public static let seasonDetail: TimeInterval = 30 * 24 * 60 * 60    // 30 d
+    public static let recommendations: TimeInterval = 7 * 24 * 60 * 60  // 7 d
+    public static let configuration: TimeInterval = 30 * 24 * 60 * 60   // 30 d
+
+    /// Search is interactive; freshness wins. Returning `0` signals the
+    /// cache should treat search responses as never-cached.
+    public static let searchMulti: TimeInterval = 0
+
+    /// Match-result cache: parsed-name → ranked-match. Lives in the same
+    /// cache layer; consulted by #17.
+    public static let matchResult: TimeInterval = 30 * 24 * 60 * 60     // 30 d
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/MetadataProvider.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/MetadataProvider.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Errors that any `MetadataProvider` impl should map its native failures
+/// onto. The concrete UI is allowed to inspect these to render calm copy
+/// per `06-brand.md § Voice` ("We can't reach the catalogue right now").
+public enum MetadataProviderError: Error, Equatable, Sendable {
+    case transport
+    case rateLimited(retryAfter: TimeInterval?)
+    case authentication
+    case http(Int)
+    case decoding(String)
+    case notFound
+    case cancelled
+}
+
+/// Single seam between the app and a metadata source. The TMDB-backed
+/// concrete impl lives in `TMDBProvider`; tests use `FakeMetadataProvider`
+/// from `Tests/Support/`. Adding new providers is one file each.
+public protocol MetadataProvider: Sendable {
+    func trending(media: TrendingMedia, window: TrendingWindow) async throws -> [MediaItem]
+    func popular(media: TrendingMedia) async throws -> [MediaItem]
+    func topRated(media: TrendingMedia) async throws -> [MediaItem]
+
+    func searchMulti(query: String) async throws -> [MediaItem]
+
+    func movieDetail(id: MediaID) async throws -> Movie
+    func showDetail(id: MediaID) async throws -> Show
+    func seasonDetail(showID: MediaID, season: Int) async throws -> Season
+
+    func recommendations(for id: MediaID) async throws -> [MediaItem]
+
+    func imageURL(path: String, size: TMDBImageSize) -> URL
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/Movie.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/Movie.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct Movie: Equatable, Sendable, Hashable, Codable {
+    public let id: MediaID
+    public let title: String
+    public let originalTitle: String
+    public let releaseYear: Int?
+    public let runtimeMinutes: Int?
+    public let overview: String
+    public let genres: [Genre]
+    /// TMDB image path (e.g. `/abc123.jpg`); combine with
+    /// `MetadataProvider.imageURL(path:size:)` to produce a full URL.
+    public let posterPath: String?
+    public let backdropPath: String?
+    public let voteAverage: Double?
+    public let popularity: Double?
+
+    public init(id: MediaID,
+                title: String,
+                originalTitle: String,
+                releaseYear: Int?,
+                runtimeMinutes: Int?,
+                overview: String,
+                genres: [Genre],
+                posterPath: String?,
+                backdropPath: String?,
+                voteAverage: Double?,
+                popularity: Double?) {
+        self.id = id
+        self.title = title
+        self.originalTitle = originalTitle
+        self.releaseYear = releaseYear
+        self.runtimeMinutes = runtimeMinutes
+        self.overview = overview
+        self.genres = genres
+        self.posterPath = posterPath
+        self.backdropPath = backdropPath
+        self.voteAverage = voteAverage
+        self.popularity = popularity
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/ParsedTitle.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/ParsedTitle.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Output of `TitleNameParser.parse(_:)`. Captures everything we can
+/// extract from a release filename without doing I/O.
+public struct ParsedTitle: Equatable, Sendable, Hashable, Codable {
+    public let title: String
+    public let year: Int?
+    public let season: Int?
+    public let episode: Int?
+    public let releaseGroup: String?
+    public let qualityHints: Set<QualityHint>
+
+    public init(title: String,
+                year: Int?,
+                season: Int?,
+                episode: Int?,
+                releaseGroup: String?,
+                qualityHints: Set<QualityHint>) {
+        self.title = title
+        self.year = year
+        self.season = season
+        self.episode = episode
+        self.releaseGroup = releaseGroup
+        self.qualityHints = qualityHints
+    }
+
+    public enum QualityHint: String, Equatable, Sendable, Hashable, Codable {
+        // Resolution
+        case p480 = "480p"
+        case p576 = "576p"
+        case p720 = "720p"
+        case p1080 = "1080p"
+        case p2160 = "2160p"
+        case uhd = "UHD"
+
+        // Source
+        case bluRay = "BluRay"
+        case webRip = "WEBRip"
+        case webDL = "WEB-DL"
+        case hdRip = "HDRip"
+        case dvdRip = "DVDRip"
+        case hdtv = "HDTV"
+        case remux = "REMUX"
+
+        // Codec
+        case x264
+        case x265
+        case h264
+        case h265
+        case hevc
+        case xvid
+        case av1 = "AV1"
+
+        // Dynamic range
+        case hdr = "HDR"
+        case hdr10 = "HDR10"
+        case dolbyVision = "DV"
+
+        // Audio
+        case dts = "DTS"
+        case ddp = "DDP"
+        case ac3 = "AC3"
+        case atmos = "Atmos"
+        case truehd = "TrueHD"
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/Season.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/Season.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct Season: Equatable, Sendable, Hashable, Codable {
+    public let showID: MediaID
+    public let seasonNumber: Int
+    public let name: String
+    public let overview: String
+    public let posterPath: String?
+    public let airDate: Date?
+    public let episodes: [Episode]
+
+    public init(showID: MediaID,
+                seasonNumber: Int,
+                name: String,
+                overview: String,
+                posterPath: String?,
+                airDate: Date?,
+                episodes: [Episode]) {
+        self.showID = showID
+        self.seasonNumber = seasonNumber
+        self.name = name
+        self.overview = overview
+        self.posterPath = posterPath
+        self.airDate = airDate
+        self.episodes = episodes
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/Show.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/Show.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct Show: Equatable, Sendable, Hashable, Codable {
+    public let id: MediaID
+    public let name: String
+    public let originalName: String
+    public let firstAirYear: Int?
+    public let lastAirYear: Int?
+    public let status: ShowStatus
+    public let overview: String
+    public let genres: [Genre]
+    public let posterPath: String?
+    public let backdropPath: String?
+    public let voteAverage: Double?
+    public let popularity: Double?
+    /// Hydrated lazily by the detail fetch; can be empty for browse-row results.
+    public let seasons: [Season]
+
+    public init(id: MediaID,
+                name: String,
+                originalName: String,
+                firstAirYear: Int?,
+                lastAirYear: Int?,
+                status: ShowStatus,
+                overview: String,
+                genres: [Genre],
+                posterPath: String?,
+                backdropPath: String?,
+                voteAverage: Double?,
+                popularity: Double?,
+                seasons: [Season]) {
+        self.id = id
+        self.name = name
+        self.originalName = originalName
+        self.firstAirYear = firstAirYear
+        self.lastAirYear = lastAirYear
+        self.status = status
+        self.overview = overview
+        self.genres = genres
+        self.posterPath = posterPath
+        self.backdropPath = backdropPath
+        self.voteAverage = voteAverage
+        self.popularity = popularity
+        self.seasons = seasons
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/ShowStatus.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/ShowStatus.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum ShowStatus: String, Equatable, Sendable, Codable, Hashable {
+    case returning
+    case ended
+    case canceled
+    case inProduction
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/TMDBImageSizes.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/TMDBImageSizes.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Single source for TMDB image-size suffixes. Each layout slot pins its
+/// 1x size and (optionally) a 2x retina size; consumers select via
+/// `select(for:retina:)`. See design § D5.
+public enum TMDBImageSize: String, Sendable, Equatable, Hashable, Codable {
+    case w92, w154, w185, w300, w342, w500, w780, w1280, h632, original
+}
+
+public enum TMDBImageSlot: Sendable, Equatable, Hashable {
+    /// Browse-row poster card.
+    case posterCard
+    /// Detail-page poster.
+    case posterDetail
+    /// Backdrop hero on detail / hub.
+    case backdrop
+    /// Episode still in season selector.
+    case episodeStill
+    /// Cast headshot.
+    case headshot
+}
+
+public enum TMDBImageSizes {
+
+    /// Returns the right image size for a given layout slot.
+    /// `retina = true` requests the 2x size where one exists.
+    public static func size(for slot: TMDBImageSlot, retina: Bool = false) -> TMDBImageSize {
+        switch (slot, retina) {
+        case (.posterCard, false):    return .w342
+        case (.posterCard, true):     return .w500
+        case (.posterDetail, false):  return .w500
+        case (.posterDetail, true):   return .w780
+        case (.backdrop, _):          return .w1280
+        case (.episodeStill, false):  return .w300
+        case (.episodeStill, true):   return .w500
+        case (.headshot, false):      return .w185
+        case (.headshot, true):       return .h632
+        }
+    }
+}
+
+/// Disk-budget configuration for the `URLCache`-backed image cache.
+public enum ImageCacheConfig {
+    /// 500 MB disk budget per design § D5.
+    public static let diskCapacityBytes: Int = 500 * 1024 * 1024
+    /// Keep memory cap modest — the OS pages disk efficiently.
+    public static let memoryCapacityBytes: Int = 64 * 1024 * 1024
+    /// Standard sandbox path: `images/` sibling of `responses/`.
+    public static let directoryName: String = "images"
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/TMDBProvider.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/TMDBProvider.swift
@@ -1,0 +1,589 @@
+import Foundation
+
+/// Hand-rolled `URLSession` implementation of `MetadataProvider` against
+/// the TMDB v3 REST API. Per design § O1, we start hand-rolled and revisit
+/// if a second-or-third endpoint takes more than a day.
+///
+/// The token is sourced from `TMDBSecrets.tmdbAccessToken` — the
+/// non-checked-in `TMDBSecrets.swift` reads it from a build-time env var
+/// or falls back to an empty string (which makes live calls fail with
+/// `.authentication`). See `TMDBSecrets.example.swift` for the template.
+public actor TMDBProvider: MetadataProvider {
+
+    public struct Config: Sendable {
+        public let apiBase: URL
+        public let imageBase: URL
+        public let bearerToken: String
+        public let language: String
+        public let region: String?
+
+        public init(apiBase: URL = URL(string: "https://api.themoviedb.org/3")!,
+                    imageBase: URL = URL(string: "https://image.tmdb.org/t/p")!,
+                    bearerToken: String,
+                    language: String = "en-US",
+                    region: String? = nil) {
+            self.apiBase = apiBase
+            self.imageBase = imageBase
+            self.bearerToken = bearerToken
+            self.language = language
+            self.region = region
+        }
+    }
+
+    private let config: Config
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let cache: MetadataCache?
+
+    public init(config: Config,
+                session: URLSession = .shared,
+                cache: MetadataCache? = nil) {
+        self.config = config
+        self.session = session
+        self.cache = cache
+
+        let d = JSONDecoder()
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        d.dateDecodingStrategy = .formatted(formatter)
+        self.decoder = d
+    }
+
+    // MARK: - MetadataProvider
+
+    public func trending(media: TrendingMedia, window: TrendingWindow) async throws -> [MediaItem] {
+        let url = endpoint("/trending/\(media.rawValue)/\(window.rawValue)")
+        let dto: PageDTO<TrendingItemDTO> = try await fetch(url: url, ttl: window == .week ? MetadataCacheTTL.trendingWeek : MetadataCacheTTL.trendingDay)
+        return dto.results.compactMap { $0.toMediaItem() }
+    }
+
+    public func popular(media: TrendingMedia) async throws -> [MediaItem] {
+        let segment = (media == .tv) ? "tv" : "movie"
+        let url = endpoint("/\(segment)/popular")
+        if media == .tv {
+            let dto: PageDTO<ShowSummaryDTO> = try await fetch(url: url, ttl: MetadataCacheTTL.popular)
+            return dto.results.map { .show($0.toShow()) }
+        } else {
+            let dto: PageDTO<MovieSummaryDTO> = try await fetch(url: url, ttl: MetadataCacheTTL.popular)
+            return dto.results.map { .movie($0.toMovie()) }
+        }
+    }
+
+    public func topRated(media: TrendingMedia) async throws -> [MediaItem] {
+        let segment = (media == .tv) ? "tv" : "movie"
+        let url = endpoint("/\(segment)/top_rated")
+        if media == .tv {
+            let dto: PageDTO<ShowSummaryDTO> = try await fetch(url: url, ttl: MetadataCacheTTL.topRated)
+            return dto.results.map { .show($0.toShow()) }
+        } else {
+            let dto: PageDTO<MovieSummaryDTO> = try await fetch(url: url, ttl: MetadataCacheTTL.topRated)
+            return dto.results.map { .movie($0.toMovie()) }
+        }
+    }
+
+    public func searchMulti(query: String) async throws -> [MediaItem] {
+        var components = URLComponents(url: endpoint("/search/multi"), resolvingAgainstBaseURL: false)!
+        components.queryItems = (components.queryItems ?? []) + [
+            URLQueryItem(name: "query", value: query),
+            URLQueryItem(name: "include_adult", value: "false")
+        ]
+        let url = components.url!
+        let dto: PageDTO<TrendingItemDTO> = try await fetch(url: url, ttl: MetadataCacheTTL.searchMulti)
+        return dto.results.compactMap { $0.toMediaItem() }
+    }
+
+    public func movieDetail(id: MediaID) async throws -> Movie {
+        precondition(id.provider == .tmdb)
+        let url = endpoint("/movie/\(id.id)")
+        let dto: MovieDetailDTO = try await fetch(url: url, ttl: MetadataCacheTTL.movieDetail)
+        return dto.toMovie()
+    }
+
+    public func showDetail(id: MediaID) async throws -> Show {
+        precondition(id.provider == .tmdb)
+        let url = endpoint("/tv/\(id.id)")
+        let dto: ShowDetailDTO = try await fetch(url: url, ttl: MetadataCacheTTL.showDetail)
+        return dto.toShow()
+    }
+
+    public func seasonDetail(showID: MediaID, season: Int) async throws -> Season {
+        precondition(showID.provider == .tmdb)
+        let url = endpoint("/tv/\(showID.id)/season/\(season)")
+        let dto: SeasonDetailDTO = try await fetch(url: url, ttl: MetadataCacheTTL.seasonDetail)
+        return dto.toSeason(showID: showID)
+    }
+
+    public func recommendations(for id: MediaID) async throws -> [MediaItem] {
+        precondition(id.provider == .tmdb)
+        // Endpoint differs by media type; try movie first, fall back to tv.
+        let movieURL = endpoint("/movie/\(id.id)/recommendations")
+        let dto: PageDTO<TrendingItemDTO> = try await fetch(url: movieURL, ttl: MetadataCacheTTL.recommendations)
+        return dto.results.compactMap { $0.toMediaItem() }
+    }
+
+    public nonisolated func imageURL(path: String, size: TMDBImageSize) -> URL {
+        // Strip a leading `/` to avoid `//` in the joined URL.
+        let trimmed = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        return config.imageBase
+            .appendingPathComponent(size.rawValue)
+            .appendingPathComponent(trimmed)
+    }
+
+    // MARK: - Internals
+
+    /// Build a fully-qualified endpoint URL with `language` (and optional
+    /// `region`) prepended as query items.
+    nonisolated func endpoint(_ path: String) -> URL {
+        var components = URLComponents(url: config.apiBase.appendingPathComponent(path),
+                                       resolvingAgainstBaseURL: false)!
+        var items = components.queryItems ?? []
+        items.append(URLQueryItem(name: "language", value: config.language))
+        if let region = config.region {
+            items.append(URLQueryItem(name: "region", value: region))
+        }
+        components.queryItems = items
+        return components.url!
+    }
+
+    private func fetch<T: Decodable>(url: URL, ttl: TimeInterval) async throws -> T {
+        // Cache check (only when ttl > 0). Stale-while-revalidate is the
+        // caller's concern; this layer just returns the freshest data we
+        // can produce synchronously.
+        if ttl > 0, let hit = cache?.lookup(url: url), hit.freshness == .fresh {
+            do {
+                return try decoder.decode(T.self, from: hit.data)
+            } catch {
+                // Corrupt cache entry; fall through to network.
+                cache?.remove(url: url)
+            }
+        }
+
+        var request = URLRequest(url: url)
+        if !config.bearerToken.isEmpty {
+            request.setValue("Bearer \(config.bearerToken)", forHTTPHeaderField: "Authorization")
+        }
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            if let urlErr = error as? URLError, urlErr.code == .cancelled {
+                throw MetadataProviderError.cancelled
+            }
+            throw MetadataProviderError.transport
+        }
+
+        if let http = response as? HTTPURLResponse {
+            switch http.statusCode {
+            case 200..<300:
+                break
+            case 401, 403:
+                throw MetadataProviderError.authentication
+            case 404:
+                throw MetadataProviderError.notFound
+            case 429:
+                let retryAfter: TimeInterval? = (http.value(forHTTPHeaderField: "Retry-After"))
+                    .flatMap(TimeInterval.init)
+                throw MetadataProviderError.rateLimited(retryAfter: retryAfter)
+            default:
+                throw MetadataProviderError.http(http.statusCode)
+            }
+
+            if ttl > 0 {
+                let etag = http.value(forHTTPHeaderField: "ETag")
+                let lastModified = http.value(forHTTPHeaderField: "Last-Modified")
+                try? cache?.store(url: url, data: data, ttl: ttl,
+                                  etag: etag, lastModified: lastModified)
+            }
+        }
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw MetadataProviderError.decoding(String(describing: error))
+        }
+    }
+}
+
+// MARK: - DTOs
+
+/// Generic paged envelope used by trending / popular / top-rated / search.
+struct PageDTO<Item: Decodable>: Decodable {
+    let results: [Item]
+}
+
+/// Multi-search / trending result that may be either movie or tv.
+struct TrendingItemDTO: Decodable {
+    let mediaType: String?
+    let id: Int64
+    let title: String?            // movie
+    let originalTitle: String?    // movie
+    let releaseDate: String?      // movie
+    let name: String?             // tv
+    let originalName: String?     // tv
+    let firstAirDate: String?     // tv
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let voteAverage: Double?
+    let popularity: Double?
+    let genreIDs: [Int]?
+
+    private enum CodingKeys: String, CodingKey {
+        case mediaType = "media_type"
+        case id, title, name, overview, popularity
+        case originalTitle = "original_title"
+        case originalName = "original_name"
+        case releaseDate = "release_date"
+        case firstAirDate = "first_air_date"
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case voteAverage = "vote_average"
+        case genreIDs = "genre_ids"
+    }
+
+    func toMediaItem() -> MediaItem? {
+        let mediaID = MediaID(provider: .tmdb, id: id)
+        let yearFrom: (String?) -> Int? = { date in
+            guard let date, date.count >= 4 else { return nil }
+            return Int(date.prefix(4))
+        }
+        let genres = (genreIDs ?? []).map { Genre(id: $0, name: "") }
+
+        if mediaType == "movie" || (mediaType == nil && title != nil) {
+            return .movie(Movie(
+                id: mediaID,
+                title: title ?? originalTitle ?? "",
+                originalTitle: originalTitle ?? title ?? "",
+                releaseYear: yearFrom(releaseDate),
+                runtimeMinutes: nil,
+                overview: overview ?? "",
+                genres: genres,
+                posterPath: posterPath,
+                backdropPath: backdropPath,
+                voteAverage: voteAverage,
+                popularity: popularity
+            ))
+        } else if mediaType == "tv" || (mediaType == nil && name != nil) {
+            return .show(Show(
+                id: mediaID,
+                name: name ?? originalName ?? "",
+                originalName: originalName ?? name ?? "",
+                firstAirYear: yearFrom(firstAirDate),
+                lastAirYear: nil,
+                status: .returning,
+                overview: overview ?? "",
+                genres: genres,
+                posterPath: posterPath,
+                backdropPath: backdropPath,
+                voteAverage: voteAverage,
+                popularity: popularity,
+                seasons: []
+            ))
+        } else {
+            // person / unknown — drop.
+            return nil
+        }
+    }
+}
+
+struct MovieSummaryDTO: Decodable {
+    let id: Int64
+    let title: String
+    let originalTitle: String?
+    let releaseDate: String?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let voteAverage: Double?
+    let popularity: Double?
+    let genreIDs: [Int]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, overview, popularity
+        case originalTitle = "original_title"
+        case releaseDate = "release_date"
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case voteAverage = "vote_average"
+        case genreIDs = "genre_ids"
+    }
+
+    func toMovie() -> Movie {
+        let year: Int? = {
+            guard let r = releaseDate, r.count >= 4 else { return nil }
+            return Int(r.prefix(4))
+        }()
+        return Movie(
+            id: MediaID(provider: .tmdb, id: id),
+            title: title,
+            originalTitle: originalTitle ?? title,
+            releaseYear: year,
+            runtimeMinutes: nil,
+            overview: overview ?? "",
+            genres: (genreIDs ?? []).map { Genre(id: $0, name: "") },
+            posterPath: posterPath,
+            backdropPath: backdropPath,
+            voteAverage: voteAverage,
+            popularity: popularity
+        )
+    }
+}
+
+struct ShowSummaryDTO: Decodable {
+    let id: Int64
+    let name: String
+    let originalName: String?
+    let firstAirDate: String?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let voteAverage: Double?
+    let popularity: Double?
+    let genreIDs: [Int]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, overview, popularity
+        case originalName = "original_name"
+        case firstAirDate = "first_air_date"
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case voteAverage = "vote_average"
+        case genreIDs = "genre_ids"
+    }
+
+    func toShow() -> Show {
+        let year: Int? = {
+            guard let r = firstAirDate, r.count >= 4 else { return nil }
+            return Int(r.prefix(4))
+        }()
+        return Show(
+            id: MediaID(provider: .tmdb, id: id),
+            name: name,
+            originalName: originalName ?? name,
+            firstAirYear: year,
+            lastAirYear: nil,
+            status: .returning,
+            overview: overview ?? "",
+            genres: (genreIDs ?? []).map { Genre(id: $0, name: "") },
+            posterPath: posterPath,
+            backdropPath: backdropPath,
+            voteAverage: voteAverage,
+            popularity: popularity,
+            seasons: []
+        )
+    }
+}
+
+struct GenreDTO: Decodable {
+    let id: Int
+    let name: String
+    func toGenre() -> Genre { Genre(id: id, name: name) }
+}
+
+struct MovieDetailDTO: Decodable {
+    let id: Int64
+    let title: String
+    let originalTitle: String?
+    let releaseDate: String?
+    let runtime: Int?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let voteAverage: Double?
+    let popularity: Double?
+    let genres: [GenreDTO]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, runtime, overview, popularity, genres
+        case originalTitle = "original_title"
+        case releaseDate = "release_date"
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case voteAverage = "vote_average"
+    }
+
+    func toMovie() -> Movie {
+        let year: Int? = {
+            guard let r = releaseDate, r.count >= 4 else { return nil }
+            return Int(r.prefix(4))
+        }()
+        return Movie(
+            id: MediaID(provider: .tmdb, id: id),
+            title: title,
+            originalTitle: originalTitle ?? title,
+            releaseYear: year,
+            runtimeMinutes: runtime,
+            overview: overview ?? "",
+            genres: (genres ?? []).map { $0.toGenre() },
+            posterPath: posterPath,
+            backdropPath: backdropPath,
+            voteAverage: voteAverage,
+            popularity: popularity
+        )
+    }
+}
+
+struct ShowDetailDTO: Decodable {
+    let id: Int64
+    let name: String
+    let originalName: String?
+    let firstAirDate: String?
+    let lastAirDate: String?
+    let status: String?
+    let inProduction: Bool?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let voteAverage: Double?
+    let popularity: Double?
+    let genres: [GenreDTO]?
+    let seasons: [SeasonSummaryDTO]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, status, overview, popularity, genres, seasons
+        case originalName = "original_name"
+        case firstAirDate = "first_air_date"
+        case lastAirDate = "last_air_date"
+        case inProduction = "in_production"
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case voteAverage = "vote_average"
+    }
+
+    func toShow() -> Show {
+        let firstYear: Int? = {
+            guard let r = firstAirDate, r.count >= 4 else { return nil }
+            return Int(r.prefix(4))
+        }()
+        let lastYear: Int? = {
+            guard let r = lastAirDate, r.count >= 4 else { return nil }
+            return Int(r.prefix(4))
+        }()
+        let mappedStatus: ShowStatus = {
+            if inProduction == true { return .inProduction }
+            switch (status ?? "").lowercased() {
+            case "returning series": return .returning
+            case "ended": return .ended
+            case "canceled", "cancelled": return .canceled
+            case "in production": return .inProduction
+            default: return .returning
+            }
+        }()
+        let showID = MediaID(provider: .tmdb, id: id)
+        let mappedSeasons: [Season] = (seasons ?? []).map { s in
+            Season(showID: showID,
+                   seasonNumber: s.seasonNumber,
+                   name: s.name ?? "Season \(s.seasonNumber)",
+                   overview: s.overview ?? "",
+                   posterPath: s.posterPath,
+                   airDate: nil,
+                   episodes: [])
+        }
+        return Show(
+            id: showID,
+            name: name,
+            originalName: originalName ?? name,
+            firstAirYear: firstYear,
+            lastAirYear: lastYear,
+            status: mappedStatus,
+            overview: overview ?? "",
+            genres: (genres ?? []).map { $0.toGenre() },
+            posterPath: posterPath,
+            backdropPath: backdropPath,
+            voteAverage: voteAverage,
+            popularity: popularity,
+            seasons: mappedSeasons
+        )
+    }
+}
+
+struct SeasonSummaryDTO: Decodable {
+    let seasonNumber: Int
+    let name: String?
+    let overview: String?
+    let posterPath: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case name, overview
+        case seasonNumber = "season_number"
+        case posterPath = "poster_path"
+    }
+}
+
+struct SeasonDetailDTO: Decodable {
+    let seasonNumber: Int
+    let name: String?
+    let overview: String?
+    let posterPath: String?
+    let airDate: String?
+    let episodes: [EpisodeDetailDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case name, overview, episodes
+        case seasonNumber = "season_number"
+        case posterPath = "poster_path"
+        case airDate = "air_date"
+    }
+
+    func toSeason(showID: MediaID) -> Season {
+        let dateFormatter: DateFormatter = {
+            let f = DateFormatter()
+            f.calendar = Calendar(identifier: .iso8601)
+            f.locale = Locale(identifier: "en_US_POSIX")
+            f.timeZone = TimeZone(secondsFromGMT: 0)
+            f.dateFormat = "yyyy-MM-dd"
+            return f
+        }()
+        let parsedAirDate: Date? = {
+            guard let s = airDate, !s.isEmpty else { return nil }
+            return dateFormatter.date(from: s)
+        }()
+        let mappedEpisodes: [Episode] = episodes.map { dto in
+            Episode(
+                id: MediaID(provider: .tmdb, id: dto.id),
+                showID: showID,
+                seasonNumber: dto.seasonNumber,
+                episodeNumber: dto.episodeNumber,
+                name: dto.name ?? "",
+                overview: dto.overview ?? "",
+                stillPath: dto.stillPath,
+                runtimeMinutes: dto.runtime,
+                airDate: dto.airDate.flatMap { dateFormatter.date(from: $0) }
+            )
+        }
+        return Season(
+            showID: showID,
+            seasonNumber: seasonNumber,
+            name: name ?? "Season \(seasonNumber)",
+            overview: overview ?? "",
+            posterPath: posterPath,
+            airDate: parsedAirDate,
+            episodes: mappedEpisodes
+        )
+    }
+}
+
+struct EpisodeDetailDTO: Decodable {
+    let id: Int64
+    let seasonNumber: Int
+    let episodeNumber: Int
+    let name: String?
+    let overview: String?
+    let stillPath: String?
+    let runtime: Int?
+    let airDate: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, overview, runtime
+        case seasonNumber = "season_number"
+        case episodeNumber = "episode_number"
+        case stillPath = "still_path"
+        case airDate = "air_date"
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/TMDBSecrets.local.swift.example
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/TMDBSecrets.local.swift.example
@@ -1,0 +1,14 @@
+// Template — copy to `TMDBSecrets.local.swift` (sibling, no `.example`) and
+// fill in your token. The `.local.swift` filename is gitignored.
+//
+// import Foundation
+//
+// /// Auto-installs the TMDB token on first import. The reference here is
+// /// the only thing that pins the closure into the binary.
+// private let _installedTMDBToken: Void = {
+//     TMDBSecrets.localTokenProvider = { "eyJhbGciOiJIUzI1NiJ9..." }
+// }()
+//
+// // Force-evaluate at process start by referencing it from a top-level
+// // expression in your app's main entry point. (For tests, the env var
+// // path is preferred.)

--- a/Packages/MetadataDomain/Sources/MetadataDomain/TMDBSecrets.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/TMDBSecrets.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Centralised access to the TMDB v4 access token used by `TMDBProvider`.
+///
+/// Resolution order:
+///   1. `TMDB_ACCESS_TOKEN` environment variable (preferred).
+///   2. `TMDBSecrets.local.swift` (gitignored) defines a
+///      `TMDBSecretsLocal.token` static; this file references it via a
+///      function pointer that the local file installs at process start.
+///   3. Empty string. With no token, live calls fail with `.authentication`.
+///
+/// The local override pattern: copy
+/// `TMDBSecrets.local.swift.example` → `TMDBSecrets.local.swift`, fill in
+/// the token, and the gitignore rule keeps it out of the repo.
+public enum TMDBSecrets {
+
+    /// Hook the local file installs at process start. `nil` means no
+    /// local override.
+    nonisolated(unsafe) public static var localTokenProvider: (@Sendable () -> String)?
+
+    public static var tmdbAccessToken: String {
+        if let env = ProcessInfo.processInfo.environment["TMDB_ACCESS_TOKEN"], !env.isEmpty {
+            return env
+        }
+        return localTokenProvider?() ?? ""
+    }
+}

--- a/Packages/MetadataDomain/Sources/MetadataDomain/TitleNameParser.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/TitleNameParser.swift
@@ -1,0 +1,310 @@
+import Foundation
+
+/// Pure, deterministic parser that extracts `(title, year, season, episode,
+/// release group, quality hints)` from common release filenames. Lives in
+/// MetadataDomain because the matching seam ranges over its output;
+/// orchestration glue (which feeds the result into a network search) lives
+/// where it's first needed.
+///
+/// No I/O, no randomness, no clock — every input maps to exactly one output.
+public enum TitleNameParser {
+
+    public static func parse(_ name: String) -> ParsedTitle {
+        // 1. Strip extension.
+        var working = stripExtension(name)
+
+        // 2. Strip wrapping brackets/parens commonly used by anime release
+        // groups before they pin the actual title (e.g. "[SubsPlease]").
+        let leadingGroup = extractLeadingBracketGroup(&working)
+
+        // 3. Quality hints. Tokenise on whitespace / brackets only — keep
+        // hyphens and dots inside tokens so `WEB-DL`, `H.264`, `H.265`,
+        // `Blu-ray`, `H-264` survive intact. Then break each composite
+        // token on dots only when it isn't itself a known quality hint
+        // (so `Web-DL` stays whole but `1080p.BluRay.x264` decomposes).
+        let qualityHints = extractQualityHints(rawName: working)
+
+        // 4. Release group: the trailing `-GROUP` suffix on the original
+        // filename (after extension strip), if any.
+        let trailingGroup = extractTrailingGroup(working)
+
+        // 5. Find season/episode marker. Range over the original (with
+        // dot/underscore separators replaced by spaces) so we can use the
+        // marker's index to cleanly split the title.
+        let titleAxis = working
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: ".", with: " ")
+
+        let seasonEpisode = findSeasonEpisode(in: titleAxis)
+
+        // 6. Year: a 4-digit year between 1900–2099 surrounded by
+        // word boundaries. If multiple, prefer one that is wrapped by `()`
+        // in the original; otherwise the last one before the season/episode
+        // marker; otherwise the first one.
+        let year = findYear(in: titleAxis, beforeIndex: seasonEpisode?.startIndex)
+
+        // 7. Title: everything before the earliest of (year, season/episode).
+        let cutoff = earliestCutoff(year: year?.range,
+                                    seasonEpisode: seasonEpisode?.startIndex,
+                                    in: titleAxis)
+        let rawTitle: String = {
+            if let cutoff {
+                return String(titleAxis[..<cutoff])
+            } else {
+                // No year, no S/E; strip trailing `-GROUP` if present.
+                if let group = trailingGroup,
+                   let dashRange = titleAxis.range(of: "-\(group)", options: .backwards) {
+                    return String(titleAxis[..<dashRange.lowerBound])
+                }
+                return titleAxis
+            }
+        }()
+
+        let title = cleanTitle(rawTitle)
+
+        return ParsedTitle(
+            title: title,
+            year: year?.value,
+            season: seasonEpisode?.season,
+            episode: seasonEpisode?.episode,
+            releaseGroup: trailingGroup ?? leadingGroup,
+            qualityHints: qualityHints
+        )
+    }
+
+    // MARK: - Stages
+
+    private static func stripExtension(_ name: String) -> String {
+        let knownExts: Set<String> = ["mkv", "mp4", "avi", "m4v", "mov", "wmv", "flv", "webm", "ts", "m2ts"]
+        if let dot = name.lastIndex(of: "."),
+           dot > name.startIndex {
+            let ext = String(name[name.index(after: dot)...]).lowercased()
+            if knownExts.contains(ext) {
+                return String(name[..<dot])
+            }
+        }
+        return name
+    }
+
+    private static func extractLeadingBracketGroup(_ working: inout String) -> String? {
+        let trimmed = working.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("[") else { return nil }
+        guard let close = trimmed.firstIndex(of: "]") else { return nil }
+        let group = String(trimmed[trimmed.index(after: trimmed.startIndex)..<close])
+        // Drop the bracketed prefix from `working`.
+        let after = trimmed.index(after: close)
+        working = String(trimmed[after...]).trimmingCharacters(in: .whitespaces)
+        return group.isEmpty ? nil : group
+    }
+
+    private static func extractTrailingGroup(_ working: String) -> String? {
+        // Pattern: `-GROUP` at the end where GROUP is alphanumeric / no spaces / no dots.
+        // Use regex against the original (which still has dots between tokens).
+        let pattern = #"-([A-Za-z0-9_]+)\s*$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsRange = NSRange(working.startIndex..., in: working)
+        guard let m = regex.firstMatch(in: working, range: nsRange),
+              m.numberOfRanges >= 2,
+              let r = Range(m.range(at: 1), in: working) else {
+            return nil
+        }
+        let candidate = String(working[r])
+        // Reject if it's clearly a quality hint, episode token, or all digits.
+        if isQualityToken(candidate) { return nil }
+        if isAllDigits(candidate) { return nil }
+        if candidate.range(of: #"^[Ss]\d+([Ee]\d+)?$"#, options: .regularExpression) != nil { return nil }
+        return candidate
+    }
+
+    private static func extractQualityHints(rawName: String) -> Set<ParsedTitle.QualityHint> {
+        // First pass: split on whitespace and brackets only.
+        let primary = rawName.split(whereSeparator: { c in
+            c == " " || c == "_" || c == "[" || c == "]" || c == "(" || c == ")"
+        }).map(String.init)
+
+        var hints: Set<ParsedTitle.QualityHint> = []
+        for primaryToken in primary {
+            // If the whole composite token matches, take it.
+            if let hint = qualityHint(for: primaryToken) {
+                hints.insert(hint)
+                continue
+            }
+            // Otherwise break on dots and dashes and try each subtoken.
+            let subtokens = primaryToken.split(whereSeparator: { $0 == "." || $0 == "-" }).map(String.init)
+            for sub in subtokens {
+                if let hint = qualityHint(for: sub) {
+                    hints.insert(hint)
+                }
+            }
+            // Special: detect "H.264" / "H.265" / "WEB.DL" patterns that
+            // were dot-joined. Look for adjacent `H` + `264`/`265` and
+            // `WEB` + `DL` runs.
+            for i in 0..<max(0, subtokens.count - 1) {
+                let pair = subtokens[i] + subtokens[i + 1]
+                let pairDotted = subtokens[i] + "." + subtokens[i + 1]
+                let pairDashed = subtokens[i] + "-" + subtokens[i + 1]
+                for candidate in [pair, pairDotted, pairDashed] {
+                    if let hint = qualityHint(for: candidate) {
+                        hints.insert(hint)
+                    }
+                }
+            }
+        }
+        return hints
+    }
+
+    private static func qualityHint(for token: String) -> ParsedTitle.QualityHint? {
+        let lower = token.lowercased()
+        switch lower {
+        case "480p": return .p480
+        case "576p": return .p576
+        case "720p": return .p720
+        case "1080p": return .p1080
+        case "2160p", "4k": return .p2160
+        case "uhd": return .uhd
+        case "bluray", "blu-ray": return .bluRay
+        case "webrip": return .webRip
+        case "web-dl", "webdl": return .webDL
+        case "hdrip": return .hdRip
+        case "dvdrip": return .dvdRip
+        case "hdtv": return .hdtv
+        case "remux": return .remux
+        case "x264": return .x264
+        case "x265": return .x265
+        case "h264", "h.264": return .h264
+        case "h265", "h.265": return .h265
+        case "hevc": return .hevc
+        case "xvid": return .xvid
+        case "av1": return .av1
+        case "hdr": return .hdr
+        case "hdr10": return .hdr10
+        case "dv": return .dolbyVision
+        case "dts": return .dts
+        case "ddp", "ddp5", "ddp5.1", "ddp2.0": return .ddp
+        case "ac3": return .ac3
+        case "atmos": return .atmos
+        case "truehd": return .truehd
+        default: return nil
+        }
+    }
+
+    private static func isQualityToken(_ s: String) -> Bool {
+        return qualityHint(for: s) != nil
+    }
+
+    private static func isAllDigits(_ s: String) -> Bool {
+        return !s.isEmpty && s.allSatisfy(\.isNumber)
+    }
+
+    private struct SeasonEpisode {
+        let season: Int
+        let episode: Int?
+        let startIndex: String.Index
+    }
+
+    private static func findSeasonEpisode(in axis: String) -> SeasonEpisode? {
+        // Pattern A: SxxEyy or SxxExx-Ezz; first wins.
+        let patternA = #"(?i)\bS(\d{1,2})E(\d{1,3})\b"#
+        if let m = firstMatch(patternA, in: axis),
+           m.numberOfRanges >= 3,
+           let sR = Range(m.range(at: 1), in: axis),
+           let eR = Range(m.range(at: 2), in: axis),
+           let s = Int(axis[sR]),
+           let e = Int(axis[eR]),
+           let whole = Range(m.range, in: axis) {
+            return SeasonEpisode(season: s, episode: e, startIndex: whole.lowerBound)
+        }
+        // Pattern B: Season-only marker, e.g. "Season 1" / "S01" without episode.
+        let patternB = #"(?i)\bS(\d{2})\b"#
+        if let m = firstMatch(patternB, in: axis),
+           m.numberOfRanges >= 2,
+           let sR = Range(m.range(at: 1), in: axis),
+           let s = Int(axis[sR]),
+           let whole = Range(m.range, in: axis) {
+            return SeasonEpisode(season: s, episode: nil, startIndex: whole.lowerBound)
+        }
+        let patternC = #"(?i)\bSeason\s+(\d{1,2})\b"#
+        if let m = firstMatch(patternC, in: axis),
+           m.numberOfRanges >= 2,
+           let sR = Range(m.range(at: 1), in: axis),
+           let s = Int(axis[sR]),
+           let whole = Range(m.range, in: axis) {
+            return SeasonEpisode(season: s, episode: nil, startIndex: whole.lowerBound)
+        }
+        // Pattern D: episode-only marker for anime: " - 12" trailing the title.
+        // Only treat as season=1 episode=N when there is no season marker
+        // and the number is between 1 and 999 with bracketed/dashed framing.
+        let patternD = #"(?<=\s-\s)(\d{1,4})(?=\s|$|\s*\[|\s*\()"#
+        if let m = firstMatch(patternD, in: axis),
+           m.numberOfRanges >= 2,
+           let nR = Range(m.range(at: 1), in: axis),
+           let n = Int(axis[nR]),
+           n >= 1, n <= 9999,
+           let whole = Range(m.range, in: axis) {
+            // Use the position before the " - " for the title cut.
+            // Walk backward 3 chars (" - ") from `whole.lowerBound`.
+            let dashStart: String.Index = {
+                let want = axis.index(whole.lowerBound, offsetBy: -3, limitedBy: axis.startIndex)
+                return want ?? whole.lowerBound
+            }()
+            return SeasonEpisode(season: 1, episode: n, startIndex: dashStart)
+        }
+        return nil
+    }
+
+    private struct YearMatch {
+        let value: Int
+        let range: Range<String.Index>
+    }
+
+    private static func findYear(in axis: String, beforeIndex limit: String.Index?) -> YearMatch? {
+        // Year between 1900 and 2099 surrounded by word boundaries.
+        let pattern = #"(?<![\dA-Za-z])(19\d{2}|20\d{2})(?![\dA-Za-z])"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsRange = NSRange(axis.startIndex..., in: axis)
+        let matches = regex.matches(in: axis, range: nsRange)
+        guard !matches.isEmpty else { return nil }
+
+        var best: YearMatch?
+        for m in matches {
+            guard let r = Range(m.range(at: 1), in: axis),
+                  let value = Int(axis[r]) else { continue }
+            if let limit, r.lowerBound >= limit {
+                continue
+            }
+            best = YearMatch(value: value, range: r)
+        }
+        if let best { return best }
+        // Fallback: take the first match even if past the limit (unusual, but safer than dropping).
+        guard let first = matches.first,
+              let r = Range(first.range(at: 1), in: axis),
+              let value = Int(axis[r]) else {
+            return nil
+        }
+        return YearMatch(value: value, range: r)
+    }
+
+    private static func earliestCutoff(year: Range<String.Index>?,
+                                       seasonEpisode: String.Index?,
+                                       in axis: String) -> String.Index? {
+        let candidates: [String.Index] = [year?.lowerBound, seasonEpisode].compactMap { $0 }
+        return candidates.min()
+    }
+
+    private static func cleanTitle(_ raw: String) -> String {
+        // Drop bracketed annotations entirely (e.g. "(2019)" leftover).
+        var s = raw
+        s = s.replacingOccurrences(of: #"\([^)]*\)"#, with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"\[[^\]]*\]"#, with: "", options: .regularExpression)
+        // Collapse repeated separators.
+        s = s.replacingOccurrences(of: #"[\.\-_]+"#, with: " ", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+        return s.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func firstMatch(_ pattern: String, in s: String) -> NSTextCheckingResult? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsRange = NSRange(s.startIndex..., in: s)
+        return regex.firstMatch(in: s, range: nsRange)
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/Fixtures/release-names.expected.json
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/Fixtures/release-names.expected.json
@@ -1,0 +1,234 @@
+{
+  "The.Matrix.1999.1080p.BluRay.x264-GROUP.mkv": {
+    "title": "The Matrix", "year": 1999, "season": null, "episode": null,
+    "releaseGroup": "GROUP", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "The.Matrix.Reloaded.2003.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "The Matrix Reloaded", "year": 2003, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Inception.2010.2160p.UHD.BluRay.x265-TERMINAL.mkv": {
+    "title": "Inception", "year": 2010, "season": null, "episode": null,
+    "releaseGroup": "TERMINAL", "qualityHints": ["2160p", "UHD", "BluRay", "x265"]
+  },
+  "The.Godfather.1972.REMUX.1080p.BluRay.AVC.DTS-HD.MA.5.1-EPSiLON.mkv": {
+    "title": "The Godfather", "year": 1972, "season": null, "episode": null,
+    "releaseGroup": "EPSiLON", "qualityHints": ["1080p", "BluRay", "REMUX", "DTS"]
+  },
+  "Pulp.Fiction.1994.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "Pulp Fiction", "year": 1994, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Schindlers.List.1993.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "Schindlers List", "year": 1993, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Forrest.Gump.1994.1080p.BluRay.x264-CtrlHD.mkv": {
+    "title": "Forrest Gump", "year": 1994, "season": null, "episode": null,
+    "releaseGroup": "CtrlHD", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "The.Dark.Knight.2008.IMAX.1080p.BluRay.x264-CtrlHD.mkv": {
+    "title": "The Dark Knight", "year": 2008, "season": null, "episode": null,
+    "releaseGroup": "CtrlHD", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Interstellar.2014.IMAX.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "Interstellar", "year": 2014, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Parasite.2019.1080p.BluRay.x264-DEPTH.mkv": {
+    "title": "Parasite", "year": 2019, "season": null, "episode": null,
+    "releaseGroup": "DEPTH", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Arrival.2016.1080p.BluRay.x265-RARBG.mkv": {
+    "title": "Arrival", "year": 2016, "season": null, "episode": null,
+    "releaseGroup": "RARBG", "qualityHints": ["1080p", "BluRay", "x265"]
+  },
+  "Joker.2019.1080p.WEBRip.x264-RARBG.mp4": {
+    "title": "Joker", "year": 2019, "season": null, "episode": null,
+    "releaseGroup": "RARBG", "qualityHints": ["1080p", "WEBRip", "x264"]
+  },
+  "Once.Upon.A.Time.In.Hollywood.2019.1080p.BluRay.x264-GECKOS.mkv": {
+    "title": "Once Upon A Time In Hollywood", "year": 2019, "season": null, "episode": null,
+    "releaseGroup": "GECKOS", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Avengers.Endgame.2019.2160p.UHD.BluRay.x265.HDR-TERMINAL.mkv": {
+    "title": "Avengers Endgame", "year": 2019, "season": null, "episode": null,
+    "releaseGroup": "TERMINAL", "qualityHints": ["2160p", "UHD", "BluRay", "x265", "HDR"]
+  },
+  "Spider-Man.Into.The.Spider-Verse.2018.1080p.BluRay.x264-SPARKS.mkv": {
+    "title": "Spider Man Into The Spider Verse", "year": 2018, "season": null, "episode": null,
+    "releaseGroup": "SPARKS", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Friends.S01E01.The.One.Where.Monica.Gets.A.Roommate.1080p.BluRay.x264-PSYCHD.mkv": {
+    "title": "Friends", "year": null, "season": 1, "episode": 1,
+    "releaseGroup": "PSYCHD", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Friends.S10E18.The.Last.One.1080p.BluRay.x264-PSYCHD.mkv": {
+    "title": "Friends", "year": null, "season": 10, "episode": 18,
+    "releaseGroup": "PSYCHD", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Breaking.Bad.S05E14.Ozymandias.1080p.BluRay.x264-DEMAND.mkv": {
+    "title": "Breaking Bad", "year": null, "season": 5, "episode": 14,
+    "releaseGroup": "DEMAND", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Game.of.Thrones.S08E06.The.Iron.Throne.1080p.WEB-DL.DD5.1.H264-GoT.mkv": {
+    "title": "Game of Thrones", "year": null, "season": 8, "episode": 6,
+    "releaseGroup": "GoT", "qualityHints": ["1080p", "WEB-DL", "h264"]
+  },
+  "The.Office.US.S03E12.Back.From.Vacation.1080p.WEB-DL.DD5.1.H264-NTb.mkv": {
+    "title": "The Office US", "year": null, "season": 3, "episode": 12,
+    "releaseGroup": "NTb", "qualityHints": ["1080p", "WEB-DL", "h264"]
+  },
+  "The.Wire.S01E01.The.Target.1080p.BluRay.x264-MARS.mkv": {
+    "title": "The Wire", "year": null, "season": 1, "episode": 1,
+    "releaseGroup": "MARS", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "The.Mandalorian.S02E08.Chapter.16.The.Rescue.2160p.WEB-DL.HDR.HEVC.DDP5.1-NTb.mkv": {
+    "title": "The Mandalorian", "year": null, "season": 2, "episode": 8,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "HDR", "hevc", "DDP"]
+  },
+  "Stranger.Things.S04E09.The.Piggyback.2160p.NF.WEB-DL.DDP5.1.HDR.x265-NTb.mkv": {
+    "title": "Stranger Things", "year": null, "season": 4, "episode": 9,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "HDR", "x265", "DDP"]
+  },
+  "Severance.S01E09.The.We.We.Are.2160p.ATVP.WEB-DL.DDP5.1.Atmos.HDR.HEVC-NTb.mkv": {
+    "title": "Severance", "year": null, "season": 1, "episode": 9,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "HDR", "hevc", "DDP", "Atmos"]
+  },
+  "Ted.Lasso.S03E12.So.Long.Farewell.1080p.ATVP.WEB-DL.DDP5.1.H.264-NTb.mkv": {
+    "title": "Ted Lasso", "year": null, "season": 3, "episode": 12,
+    "releaseGroup": "NTb", "qualityHints": ["1080p", "WEB-DL", "h264", "DDP"]
+  },
+  "Succession.S04E10.With.Open.Eyes.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv": {
+    "title": "Succession", "year": null, "season": 4, "episode": 10,
+    "releaseGroup": "NTb", "qualityHints": ["1080p", "WEB-DL", "h264", "DDP"]
+  },
+  "House.of.the.Dragon.S01E10.The.Black.Queen.2160p.HMAX.WEB-DL.DDP5.1.HDR.HEVC-NTb.mkv": {
+    "title": "House of the Dragon", "year": null, "season": 1, "episode": 10,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "HDR", "hevc", "DDP"]
+  },
+  "Andor.S01E12.Rix.Road.2160p.DSNP.WEB-DL.DDP5.1.Atmos.HDR.HEVC-NTb.mkv": {
+    "title": "Andor", "year": null, "season": 1, "episode": 12,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "HDR", "hevc", "DDP", "Atmos"]
+  },
+  "Better.Call.Saul.S06E13.Saul.Gone.2160p.NF.WEB-DL.DDP5.1.HDR.x265-NTb.mkv": {
+    "title": "Better Call Saul", "year": null, "season": 6, "episode": 13,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "HDR", "x265", "DDP"]
+  },
+  "The.Last.of.Us.S01E03.Long.Long.Time.2160p.HMAX.WEB-DL.DDP5.1.HDR.HEVC-NTb.mkv": {
+    "title": "The Last of Us", "year": null, "season": 1, "episode": 3,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "HDR", "hevc", "DDP"]
+  },
+  "[SubsPlease] Spy x Family - 12 (1080p) [ABCDEF12].mkv": {
+    "title": "Spy x Family", "year": null, "season": 1, "episode": 12,
+    "releaseGroup": "SubsPlease", "qualityHints": ["1080p"]
+  },
+  "[Erai-raws] Frieren - Beyond Journeys End - 01 [1080p][HEVC][Multiple Subtitle].mkv": {
+    "title": "Frieren Beyond Journeys End", "year": null, "season": 1, "episode": 1,
+    "releaseGroup": "Erai-raws", "qualityHints": ["1080p", "hevc"]
+  },
+  "[HorribleSubs] Attack on Titan - 25 [720p].mkv": {
+    "title": "Attack on Titan", "year": null, "season": 1, "episode": 25,
+    "releaseGroup": "HorribleSubs", "qualityHints": ["720p"]
+  },
+  "[Judas] Demon Slayer - Kimetsu no Yaiba - S01E01 [BD 1080p][HEVC x265 10bit][Eng-Subs].mkv": {
+    "title": "Demon Slayer Kimetsu no Yaiba", "year": null, "season": 1, "episode": 1,
+    "releaseGroup": "Judas", "qualityHints": ["1080p", "hevc", "x265"]
+  },
+  "[Anime Time] One Piece - 1071 [1080p][HEVC 10bit x265][AAC][Eng Sub].mkv": {
+    "title": "One Piece", "year": null, "season": 1, "episode": 1071,
+    "releaseGroup": "Anime Time", "qualityHints": ["1080p", "hevc", "x265"]
+  },
+  "Amelie.2001.FRENCH.1080p.BluRay.x264-FiCO.mkv": {
+    "title": "Amelie", "year": 2001, "season": null, "episode": null,
+    "releaseGroup": "FiCO", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "City.of.God.2002.PORTUGUESE.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "City of God", "year": 2002, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Oldboy.2003.KOREAN.1080p.BluRay.x264-CtrlHD.mkv": {
+    "title": "Oldboy", "year": 2003, "season": null, "episode": null,
+    "releaseGroup": "CtrlHD", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Crouching.Tiger.Hidden.Dragon.2000.MANDARIN.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "Crouching Tiger Hidden Dragon", "year": 2000, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Pans.Labyrinth.2006.SPANISH.1080p.BluRay.x264-EbP.mkv": {
+    "title": "Pans Labyrinth", "year": 2006, "season": null, "episode": null,
+    "releaseGroup": "EbP", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Rocky.II.1979.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "Rocky II", "year": 1979, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Rocky.2.1979.1080p.BluRay.x264-FAKE.mkv": {
+    "title": "Rocky 2", "year": 1979, "season": null, "episode": null,
+    "releaseGroup": "FAKE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Star.Wars.Episode.IV.A.New.Hope.1977.1080p.BluRay.x264-CtrlHD.mkv": {
+    "title": "Star Wars Episode IV A New Hope", "year": 1977, "season": null, "episode": null,
+    "releaseGroup": "CtrlHD", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Mission.Impossible.III.2006.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "Mission Impossible III", "year": 2006, "season": null, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Avatar.The.Way.of.Water.2022.2160p.UHD.BluRay.x265.10bit.HDR-TERMINAL.mkv": {
+    "title": "Avatar The Way of Water", "year": 2022, "season": null, "episode": null,
+    "releaseGroup": "TERMINAL", "qualityHints": ["2160p", "UHD", "BluRay", "x265", "HDR"]
+  },
+  "Top.Gun.Maverick.2022.IMAX.1080p.BluRay.x264-PIGNUS.mkv": {
+    "title": "Top Gun Maverick", "year": 2022, "season": null, "episode": null,
+    "releaseGroup": "PIGNUS", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Dune.2021.2160p.UHD.BluRay.x265.10bit.HDR.DV-TERMINAL.mkv": {
+    "title": "Dune", "year": 2021, "season": null, "episode": null,
+    "releaseGroup": "TERMINAL", "qualityHints": ["2160p", "UHD", "BluRay", "x265", "HDR", "DV"]
+  },
+  "Dune.Part.Two.2024.1080p.BluRay.x264-GROUP.mkv": {
+    "title": "Dune Part Two", "year": 2024, "season": null, "episode": null,
+    "releaseGroup": "GROUP", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Oppenheimer.2023.IMAX.2160p.UHD.BluRay.x265.10bit.HDR-TERMINAL.mkv": {
+    "title": "Oppenheimer", "year": 2023, "season": null, "episode": null,
+    "releaseGroup": "TERMINAL", "qualityHints": ["2160p", "UHD", "BluRay", "x265", "HDR"]
+  },
+  "Barbie.2023.1080p.WEB-DL.DDP5.1.Atmos.H.264-RARBG.mkv": {
+    "title": "Barbie", "year": 2023, "season": null, "episode": null,
+    "releaseGroup": "RARBG", "qualityHints": ["1080p", "WEB-DL", "h264", "DDP", "Atmos"]
+  },
+  "Killers.of.the.Flower.Moon.2023.2160p.ATVP.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-NTb.mkv": {
+    "title": "Killers of the Flower Moon", "year": 2023, "season": null, "episode": null,
+    "releaseGroup": "NTb", "qualityHints": ["2160p", "WEB-DL", "h265", "HDR", "DDP", "Atmos", "DV"]
+  },
+  "The.Bear.S02E07.Forks.1080p.HULU.WEB-DL.DDP5.1.H.264-NTb.mkv": {
+    "title": "The Bear", "year": null, "season": 2, "episode": 7,
+    "releaseGroup": "NTb", "qualityHints": ["1080p", "WEB-DL", "h264", "DDP"]
+  },
+  "Chernobyl.S01E05.Vichnaya.Pamyat.1080p.BluRay.x264-DEMAND.mkv": {
+    "title": "Chernobyl", "year": null, "season": 1, "episode": 5,
+    "releaseGroup": "DEMAND", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Sherlock.S04E03.The.Final.Problem.1080p.BluRay.x264-SHORTBREHD.mkv": {
+    "title": "Sherlock", "year": null, "season": 4, "episode": 3,
+    "releaseGroup": "SHORTBREHD", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Mr.Robot.S04E13.Hello.Elliot.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv": {
+    "title": "Mr Robot", "year": null, "season": 4, "episode": 13,
+    "releaseGroup": "NTb", "qualityHints": ["1080p", "WEB-DL", "h264", "DDP"]
+  },
+  "Westworld.Season.1.Complete.1080p.BluRay.x264-DEFLATE.mkv": {
+    "title": "Westworld", "year": null, "season": 1, "episode": null,
+    "releaseGroup": "DEFLATE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "The.Sopranos.S06E21.Made.in.America.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "The Sopranos", "year": null, "season": 6, "episode": 21,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  },
+  "Lost.Season.6.1080p.BluRay.x264-AMIABLE.mkv": {
+    "title": "Lost", "year": null, "season": 6, "episode": null,
+    "releaseGroup": "AMIABLE", "qualityHints": ["1080p", "BluRay", "x264"]
+  }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/Fixtures/release-names.txt
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/Fixtures/release-names.txt
@@ -1,0 +1,63 @@
+# Release-name fixture for TitleNameParserTests.
+# Format: one release name per line. Blank lines and lines beginning with `#`
+# are ignored. Each non-comment line has a sibling `<line>.expected.json` —
+# but to keep the directory manageable, the expected outputs are bundled in
+# `release-names.expected.json` (one map keyed by the input string).
+The.Matrix.1999.1080p.BluRay.x264-GROUP.mkv
+The.Matrix.Reloaded.2003.1080p.BluRay.x264-AMIABLE.mkv
+Inception.2010.2160p.UHD.BluRay.x265-TERMINAL.mkv
+The.Godfather.1972.REMUX.1080p.BluRay.AVC.DTS-HD.MA.5.1-EPSiLON.mkv
+Pulp.Fiction.1994.1080p.BluRay.x264-AMIABLE.mkv
+Schindlers.List.1993.1080p.BluRay.x264-AMIABLE.mkv
+Forrest.Gump.1994.1080p.BluRay.x264-CtrlHD.mkv
+The.Dark.Knight.2008.IMAX.1080p.BluRay.x264-CtrlHD.mkv
+Interstellar.2014.IMAX.1080p.BluRay.x264-AMIABLE.mkv
+Parasite.2019.1080p.BluRay.x264-DEPTH.mkv
+Arrival.2016.1080p.BluRay.x265-RARBG.mkv
+Joker.2019.1080p.WEBRip.x264-RARBG.mp4
+Once.Upon.A.Time.In.Hollywood.2019.1080p.BluRay.x264-GECKOS.mkv
+Avengers.Endgame.2019.2160p.UHD.BluRay.x265.HDR-TERMINAL.mkv
+Spider-Man.Into.The.Spider-Verse.2018.1080p.BluRay.x264-SPARKS.mkv
+Friends.S01E01.The.One.Where.Monica.Gets.A.Roommate.1080p.BluRay.x264-PSYCHD.mkv
+Friends.S10E18.The.Last.One.1080p.BluRay.x264-PSYCHD.mkv
+Breaking.Bad.S05E14.Ozymandias.1080p.BluRay.x264-DEMAND.mkv
+Game.of.Thrones.S08E06.The.Iron.Throne.1080p.WEB-DL.DD5.1.H264-GoT.mkv
+The.Office.US.S03E12.Back.From.Vacation.1080p.WEB-DL.DD5.1.H264-NTb.mkv
+The.Wire.S01E01.The.Target.1080p.BluRay.x264-MARS.mkv
+The.Mandalorian.S02E08.Chapter.16.The.Rescue.2160p.WEB-DL.HDR.HEVC.DDP5.1-NTb.mkv
+Stranger.Things.S04E09.The.Piggyback.2160p.NF.WEB-DL.DDP5.1.HDR.x265-NTb.mkv
+Severance.S01E09.The.We.We.Are.2160p.ATVP.WEB-DL.DDP5.1.Atmos.HDR.HEVC-NTb.mkv
+Ted.Lasso.S03E12.So.Long.Farewell.1080p.ATVP.WEB-DL.DDP5.1.H.264-NTb.mkv
+Succession.S04E10.With.Open.Eyes.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv
+House.of.the.Dragon.S01E10.The.Black.Queen.2160p.HMAX.WEB-DL.DDP5.1.HDR.HEVC-NTb.mkv
+Andor.S01E12.Rix.Road.2160p.DSNP.WEB-DL.DDP5.1.Atmos.HDR.HEVC-NTb.mkv
+Better.Call.Saul.S06E13.Saul.Gone.2160p.NF.WEB-DL.DDP5.1.HDR.x265-NTb.mkv
+The.Last.of.Us.S01E03.Long.Long.Time.2160p.HMAX.WEB-DL.DDP5.1.HDR.HEVC-NTb.mkv
+[SubsPlease] Spy x Family - 12 (1080p) [ABCDEF12].mkv
+[Erai-raws] Frieren - Beyond Journeys End - 01 [1080p][HEVC][Multiple Subtitle].mkv
+[HorribleSubs] Attack on Titan - 25 [720p].mkv
+[Judas] Demon Slayer - Kimetsu no Yaiba - S01E01 [BD 1080p][HEVC x265 10bit][Eng-Subs].mkv
+[Anime Time] One Piece - 1071 [1080p][HEVC 10bit x265][AAC][Eng Sub].mkv
+Amelie.2001.FRENCH.1080p.BluRay.x264-FiCO.mkv
+City.of.God.2002.PORTUGUESE.1080p.BluRay.x264-AMIABLE.mkv
+Oldboy.2003.KOREAN.1080p.BluRay.x264-CtrlHD.mkv
+Crouching.Tiger.Hidden.Dragon.2000.MANDARIN.1080p.BluRay.x264-AMIABLE.mkv
+Pans.Labyrinth.2006.SPANISH.1080p.BluRay.x264-EbP.mkv
+Rocky.II.1979.1080p.BluRay.x264-AMIABLE.mkv
+Rocky.2.1979.1080p.BluRay.x264-FAKE.mkv
+Star.Wars.Episode.IV.A.New.Hope.1977.1080p.BluRay.x264-CtrlHD.mkv
+Mission.Impossible.III.2006.1080p.BluRay.x264-AMIABLE.mkv
+Avatar.The.Way.of.Water.2022.2160p.UHD.BluRay.x265.10bit.HDR-TERMINAL.mkv
+Top.Gun.Maverick.2022.IMAX.1080p.BluRay.x264-PIGNUS.mkv
+Dune.2021.2160p.UHD.BluRay.x265.10bit.HDR.DV-TERMINAL.mkv
+Dune.Part.Two.2024.1080p.BluRay.x264-GROUP.mkv
+Oppenheimer.2023.IMAX.2160p.UHD.BluRay.x265.10bit.HDR-TERMINAL.mkv
+Barbie.2023.1080p.WEB-DL.DDP5.1.Atmos.H.264-RARBG.mkv
+Killers.of.the.Flower.Moon.2023.2160p.ATVP.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-NTb.mkv
+The.Bear.S02E07.Forks.1080p.HULU.WEB-DL.DDP5.1.H.264-NTb.mkv
+Chernobyl.S01E05.Vichnaya.Pamyat.1080p.BluRay.x264-DEMAND.mkv
+Sherlock.S04E03.The.Final.Problem.1080p.BluRay.x264-SHORTBREHD.mkv
+Mr.Robot.S04E13.Hello.Elliot.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv
+Westworld.Season.1.Complete.1080p.BluRay.x264-DEFLATE.mkv
+The.Sopranos.S06E21.Made.in.America.1080p.BluRay.x264-AMIABLE.mkv
+Lost.Season.6.1080p.BluRay.x264-AMIABLE.mkv

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/ImageCacheTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/ImageCacheTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import MetadataDomain
+
+final class ImageCacheTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ImageCacheTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        tempDir = base
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        tempDir = nil
+    }
+
+    // MARK: - URLCache configuration
+
+    func test_init_configuresURLCacheWithBudgetAndDirectory() throws {
+        let cache = try ImageCache(baseDirectory: tempDir)
+
+        XCTAssertEqual(cache.urlCache.diskCapacity, ImageCacheConfig.diskCapacityBytes)
+        XCTAssertEqual(cache.urlCache.memoryCapacity, ImageCacheConfig.memoryCapacityBytes)
+
+        // Directory is `metadata/images/` relative to the base.
+        XCTAssertEqual(cache.diskPath.lastPathComponent, "images")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cache.diskPath.path))
+    }
+
+    func test_diskCapacity_is500MB() {
+        XCTAssertEqual(ImageCacheConfig.diskCapacityBytes, 500 * 1024 * 1024)
+    }
+
+    // MARK: - Failure-mode placeholder (typed error, not raw URL)
+
+    func test_unreachableURL_returnsTransportFailure() async throws {
+        let cache = try ImageCache(baseDirectory: tempDir)
+        // Use a port that is essentially never listening.
+        let url = URL(string: "http://127.0.0.1:1/nope.jpg")!
+        let result = await cache.data(for: url)
+        switch result {
+        case .failure: break
+        case .success:
+            XCTFail("Unreachable URL should not succeed.")
+        }
+    }
+
+    // MARK: - Size-suffix selection
+
+    func test_posterCard_default_isW342() {
+        XCTAssertEqual(TMDBImageSizes.size(for: .posterCard), .w342)
+    }
+
+    func test_posterCard_retina_isW500() {
+        XCTAssertEqual(TMDBImageSizes.size(for: .posterCard, retina: true), .w500)
+    }
+
+    func test_posterDetail_default_isW500() {
+        XCTAssertEqual(TMDBImageSizes.size(for: .posterDetail), .w500)
+    }
+
+    func test_posterDetail_retina_isW780() {
+        XCTAssertEqual(TMDBImageSizes.size(for: .posterDetail, retina: true), .w780)
+    }
+
+    func test_backdrop_isW1280() {
+        XCTAssertEqual(TMDBImageSizes.size(for: .backdrop), .w1280)
+        XCTAssertEqual(TMDBImageSizes.size(for: .backdrop, retina: true), .w1280)
+    }
+
+    func test_episodeStill_default_isW300() {
+        XCTAssertEqual(TMDBImageSizes.size(for: .episodeStill), .w300)
+    }
+
+    func test_episodeStill_retina_isW500() {
+        XCTAssertEqual(TMDBImageSizes.size(for: .episodeStill, retina: true), .w500)
+    }
+
+    func test_size_rawValue_matchesTMDBPathSegment() {
+        // Sanity: the rawValue is the literal TMDB path segment used to
+        // build image URLs (e.g. `/t/p/w342/poster.jpg`).
+        XCTAssertEqual(TMDBImageSize.w342.rawValue, "w342")
+        XCTAssertEqual(TMDBImageSize.w1280.rawValue, "w1280")
+        XCTAssertEqual(TMDBImageSize.original.rawValue, "original")
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/MatchRankerTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/MatchRankerTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import MetadataDomain
+
+final class MatchRankerTests: XCTestCase {
+
+    // MARK: - Top match exceeds threshold
+
+    func test_perfectMatch_movie_topResultAboveThreshold() {
+        let parsed = parsedTitle("The Matrix", year: 1999)
+        let matrix1999 = movieItem(id: 603, title: "The Matrix", year: 1999)
+        let bullets = movieItem(id: 604, title: "Bulletproof", year: 1996)
+        let ranked = MatchRanker.rank(parsed: parsed, candidates: [bullets, matrix1999])
+        XCTAssertEqual(ranked.first?.item, matrix1999)
+        XCTAssertGreaterThanOrEqual(ranked.first?.confidence ?? 0, MatchRanker.defaultThreshold)
+    }
+
+    func test_perfectMatch_show_topResultAboveThreshold() {
+        let parsed = parsedTitle("Friends", season: 1, episode: 1)
+        let friends = showItem(id: 1668, name: "Friends", firstAirYear: 1994)
+        let ranked = MatchRanker.rank(parsed: parsed, candidates: [friends])
+        XCTAssertGreaterThanOrEqual(ranked.first?.confidence ?? 0, MatchRanker.defaultThreshold)
+    }
+
+    // MARK: - Wrong-year demotion
+
+    func test_wrongYear_demotedBelowSameYearMatch() {
+        let parsed = parsedTitle("The Matrix", year: 1999)
+        let matrix1999 = movieItem(id: 603, title: "The Matrix", year: 1999)
+        let matrix2010 = movieItem(id: 999, title: "The Matrix", year: 2010)
+        let ranked = MatchRanker.rank(parsed: parsed, candidates: [matrix2010, matrix1999])
+        XCTAssertEqual(ranked.first?.item, matrix1999)
+        XCTAssertGreaterThan(ranked[0].confidence, ranked[1].confidence)
+        XCTAssertTrue(ranked.last?.reasons.contains(where: { $0.contains("year=miss") }) ?? false)
+    }
+
+    // MARK: - Different show with same title
+
+    func test_differentShowSameTitle_yearBreaksTie() {
+        let parsed = parsedTitle("Doctor Who", year: 2005, season: 1, episode: 1)
+        let classic = showItem(id: 76285, name: "Doctor Who", firstAirYear: 1963)
+        let modern = showItem(id: 57243, name: "Doctor Who", firstAirYear: 2005)
+        let ranked = MatchRanker.rank(parsed: parsed, candidates: [classic, modern])
+        XCTAssertEqual(ranked.first?.item, modern)
+    }
+
+    // MARK: - Roman numerals
+
+    func test_romanNumeralSequel_doesNotMatchArabic() {
+        let parsed = parsedTitle("Rocky II", year: 1979)
+        let rocky2 = movieItem(id: 1366, title: "Rocky 2", year: 1979)
+        let rockyII = movieItem(id: 1259, title: "Rocky II", year: 1979)
+        let ranked = MatchRanker.rank(parsed: parsed, candidates: [rocky2, rockyII])
+        XCTAssertEqual(ranked.first?.item, rockyII)
+        XCTAssertGreaterThan(ranked[0].confidence, ranked[1].confidence)
+    }
+
+    // MARK: - Show-vs-movie shape
+
+    func test_parsedIsShowShape_movieCandidateDemoted() {
+        let parsed = parsedTitle("Westworld", season: 1, episode: 1)
+        let movieWW = movieItem(id: 11, title: "Westworld", year: 1973)
+        let showWW = showItem(id: 63247, name: "Westworld", firstAirYear: 2016)
+        let ranked = MatchRanker.rank(parsed: parsed, candidates: [movieWW, showWW])
+        XCTAssertEqual(ranked.first?.item, showWW)
+    }
+
+    // MARK: - Reasons surfaced
+
+    func test_rankedMatch_reasons_includeTitleAndYear() {
+        let parsed = parsedTitle("Inception", year: 2010)
+        let item = movieItem(id: 27205, title: "Inception", year: 2010)
+        let r = MatchRanker.rank(parsed: parsed, candidates: [item]).first!
+        XCTAssertTrue(r.reasons.contains(where: { $0.contains("title-sim=") }))
+        XCTAssertTrue(r.reasons.contains(where: { $0.contains("year=") }))
+        XCTAssertTrue(r.reasons.contains(where: { $0.contains("shape=") }))
+    }
+
+    func test_rank_orderingIsDeterministic_acrossInvocations() {
+        let parsed = parsedTitle("The Matrix", year: 1999)
+        let candidates: [MediaItem] = [
+            movieItem(id: 1, title: "The Matrix", year: 1999),
+            movieItem(id: 2, title: "The Matrix", year: 2010),
+            movieItem(id: 3, title: "Bulletproof", year: 1996)
+        ]
+        let a = MatchRanker.rank(parsed: parsed, candidates: candidates).map(\.item)
+        let b = MatchRanker.rank(parsed: parsed, candidates: candidates).map(\.item)
+        XCTAssertEqual(a, b)
+    }
+
+    // MARK: - Empty candidates
+
+    func test_emptyCandidates_returnsEmpty() {
+        let parsed = parsedTitle("Nothing")
+        XCTAssertEqual(MatchRanker.rank(parsed: parsed, candidates: []).count, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func parsedTitle(_ title: String,
+                             year: Int? = nil,
+                             season: Int? = nil,
+                             episode: Int? = nil) -> ParsedTitle {
+        ParsedTitle(title: title, year: year, season: season, episode: episode,
+                    releaseGroup: nil, qualityHints: [])
+    }
+
+    private func movieItem(id: Int64, title: String, year: Int?) -> MediaItem {
+        .movie(Movie(
+            id: MediaID(provider: .tmdb, id: id),
+            title: title,
+            originalTitle: title,
+            releaseYear: year,
+            runtimeMinutes: nil,
+            overview: "",
+            genres: [],
+            posterPath: nil,
+            backdropPath: nil,
+            voteAverage: nil,
+            popularity: nil
+        ))
+    }
+
+    private func showItem(id: Int64, name: String, firstAirYear: Int?) -> MediaItem {
+        .show(Show(
+            id: MediaID(provider: .tmdb, id: id),
+            name: name,
+            originalName: name,
+            firstAirYear: firstAirYear,
+            lastAirYear: nil,
+            status: .returning,
+            overview: "",
+            genres: [],
+            posterPath: nil,
+            backdropPath: nil,
+            voteAverage: nil,
+            popularity: nil,
+            seasons: []
+        ))
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/MediaIDTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/MediaIDTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import MetadataDomain
+
+final class MediaIDTests: XCTestCase {
+
+    func test_equality_sameProviderAndID_isEqual() {
+        let a = MediaID(provider: .tmdb, id: 1668)
+        let b = MediaID(provider: .tmdb, id: 1668)
+        XCTAssertEqual(a, b)
+    }
+
+    func test_equality_differentID_notEqual() {
+        let a = MediaID(provider: .tmdb, id: 1)
+        let b = MediaID(provider: .tmdb, id: 2)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func test_hashing_equalIDs_haveEqualHashes() {
+        let a = MediaID(provider: .tmdb, id: 42)
+        let b = MediaID(provider: .tmdb, id: 42)
+        var set: Set<MediaID> = []
+        set.insert(a)
+        set.insert(b)
+        XCTAssertEqual(set.count, 1)
+    }
+
+    func test_codable_roundTrip() throws {
+        let original = MediaID(provider: .tmdb, id: 1668)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MediaID.self, from: data)
+        XCTAssertEqual(original, decoded)
+    }
+
+    func test_codable_jsonShape() throws {
+        let id = MediaID(provider: .tmdb, id: 1668)
+        let data = try JSONEncoder().encode(id)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["provider"] as? String, "tmdb")
+        XCTAssertEqual(json["id"] as? Int64, 1668)
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/MediaItemCodableTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/MediaItemCodableTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import MetadataDomain
+
+final class MediaItemCodableTests: XCTestCase {
+
+    // MARK: - Round-trips
+
+    func test_movie_roundTrip() throws {
+        let movie = Self.sampleMovie()
+        try assertCodableRoundTrip(movie)
+    }
+
+    func test_show_roundTrip() throws {
+        let show = Self.sampleShow()
+        try assertCodableRoundTrip(show)
+    }
+
+    func test_season_roundTrip() throws {
+        let season = Self.sampleSeason()
+        try assertCodableRoundTrip(season)
+    }
+
+    func test_episode_roundTrip() throws {
+        let episode = Self.sampleEpisode()
+        try assertCodableRoundTrip(episode)
+    }
+
+    func test_genre_roundTrip() throws {
+        try assertCodableRoundTrip(Genre(id: 28, name: "Action"))
+    }
+
+    func test_showStatus_eachCase_roundTrips() throws {
+        for status in [ShowStatus.returning, .ended, .canceled, .inProduction] {
+            try assertCodableRoundTrip(status)
+        }
+    }
+
+    func test_mediaItem_movieCase_roundTrip() throws {
+        let item = MediaItem.movie(Self.sampleMovie())
+        try assertCodableRoundTrip(item)
+    }
+
+    func test_mediaItem_showCase_roundTrip() throws {
+        let item = MediaItem.show(Self.sampleShow())
+        try assertCodableRoundTrip(item)
+    }
+
+    func test_mediaItem_id_returnsUnderlyingID() {
+        let movie = Self.sampleMovie()
+        XCTAssertEqual(MediaItem.movie(movie).id, movie.id)
+
+        let show = Self.sampleShow()
+        XCTAssertEqual(MediaItem.show(show).id, show.id)
+    }
+
+    // MARK: - Schema shape (JSON snapshot guards)
+
+    func test_movie_jsonSchemaShape() throws {
+        let movie = Self.sampleMovie()
+        let json = try jsonObject(for: movie)
+        // Sentinel keys present.
+        for key in ["id", "title", "originalTitle", "releaseYear",
+                    "runtimeMinutes", "overview", "genres", "posterPath",
+                    "backdropPath", "voteAverage", "popularity"] {
+            XCTAssertNotNil(json[key], "missing key: \(key)")
+        }
+    }
+
+    func test_show_jsonSchemaShape() throws {
+        let show = Self.sampleShow()
+        let json = try jsonObject(for: show)
+        for key in ["id", "name", "originalName", "firstAirYear",
+                    "lastAirYear", "status", "overview", "genres",
+                    "posterPath", "backdropPath", "voteAverage",
+                    "popularity", "seasons"] {
+            XCTAssertNotNil(json[key], "missing key: \(key)")
+        }
+    }
+
+    func test_episode_jsonSchemaShape() throws {
+        let json = try jsonObject(for: Self.sampleEpisode())
+        for key in ["id", "showID", "seasonNumber", "episodeNumber",
+                    "name", "overview", "stillPath", "runtimeMinutes",
+                    "airDate"] {
+            XCTAssertNotNil(json[key], "missing key: \(key)")
+        }
+    }
+
+    func test_mediaItem_movie_jsonShape_carriesDiscriminator() throws {
+        let data = try JSONEncoder().encode(MediaItem.movie(Self.sampleMovie()))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        // Swift synthesises `{ "movie": { ... } }` for enums with associated values.
+        XCTAssertNotNil(json["movie"])
+        XCTAssertNil(json["show"])
+    }
+
+    func test_mediaItem_show_jsonShape_carriesDiscriminator() throws {
+        let data = try JSONEncoder().encode(MediaItem.show(Self.sampleShow()))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNotNil(json["show"])
+        XCTAssertNil(json["movie"])
+    }
+
+    // MARK: - Helpers
+
+    private func assertCodableRoundTrip<T: Codable & Equatable>(
+        _ value: T,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let data = try encoder.encode(value)
+        let decoded = try decoder.decode(T.self, from: data)
+        XCTAssertEqual(value, decoded, file: file, line: line)
+    }
+
+    private func jsonObject<T: Encodable>(for value: T) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - Fixtures
+
+    static func sampleMovie() -> Movie {
+        Movie(
+            id: MediaID(provider: .tmdb, id: 1668),
+            title: "Friends",
+            originalTitle: "Friends",
+            releaseYear: 1994,
+            runtimeMinutes: 22,
+            overview: "Six friends.",
+            genres: [Genre(id: 35, name: "Comedy")],
+            posterPath: "/poster.jpg",
+            backdropPath: "/backdrop.jpg",
+            voteAverage: 8.4,
+            popularity: 250.0
+        )
+    }
+
+    static func sampleShow() -> Show {
+        Show(
+            id: MediaID(provider: .tmdb, id: 1668),
+            name: "Friends",
+            originalName: "Friends",
+            firstAirYear: 1994,
+            lastAirYear: 2004,
+            status: .ended,
+            overview: "Six friends in NYC.",
+            genres: [Genre(id: 35, name: "Comedy")],
+            posterPath: "/poster.jpg",
+            backdropPath: "/backdrop.jpg",
+            voteAverage: 8.4,
+            popularity: 250.0,
+            seasons: [sampleSeason()]
+        )
+    }
+
+    static func sampleSeason() -> Season {
+        Season(
+            showID: MediaID(provider: .tmdb, id: 1668),
+            seasonNumber: 1,
+            name: "Season 1",
+            overview: "The first season.",
+            posterPath: "/season1.jpg",
+            airDate: Date(timeIntervalSince1970: 778464000),
+            episodes: [sampleEpisode()]
+        )
+    }
+
+    static func sampleEpisode() -> Episode {
+        Episode(
+            id: MediaID(provider: .tmdb, id: 85987),
+            showID: MediaID(provider: .tmdb, id: 1668),
+            seasonNumber: 1,
+            episodeNumber: 1,
+            name: "The One Where Monica Gets a Roommate",
+            overview: "Pilot.",
+            stillPath: "/still.jpg",
+            runtimeMinutes: 22,
+            airDate: Date(timeIntervalSince1970: 778464000)
+        )
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/MetadataCacheTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/MetadataCacheTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import MetadataDomain
+
+final class MetadataCacheTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MetadataCacheTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        tempDir = base
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        tempDir = nil
+    }
+
+    // MARK: - Basic round-trip
+
+    func test_storeAndLookup_freshHit() throws {
+        let cache = try MetadataCache(baseDirectory: tempDir)
+        let url = URL(string: "https://api.themoviedb.org/3/movie/1668")!
+        try cache.store(url: url, data: Data("{\"id\":1668}".utf8), ttl: 60)
+
+        let hit = try XCTUnwrap(cache.lookup(url: url))
+        XCTAssertEqual(hit.freshness, .fresh)
+        XCTAssertEqual(String(data: hit.data, encoding: .utf8), "{\"id\":1668}")
+    }
+
+    func test_lookup_missingURL_returnsNil() throws {
+        let cache = try MetadataCache(baseDirectory: tempDir)
+        XCTAssertNil(cache.lookup(url: URL(string: "https://example.com/missing")!))
+    }
+
+    // MARK: - TTL expiry (injected clock)
+
+    func test_lookup_pastExpiry_returnsStale() throws {
+        let instant = MutableInstant(Date(timeIntervalSince1970: 1_000_000))
+        let clock = CacheClock(now: { instant.value })
+        let cache = try MetadataCache(baseDirectory: tempDir, clock: clock)
+        let url = URL(string: "https://api.themoviedb.org/3/trending/movie/week")!
+        try cache.store(url: url, data: Data("{\"results\":[]}".utf8), ttl: 60)
+
+        // 30 s later — still fresh.
+        instant.advance(by: 30)
+        let fresh = try XCTUnwrap(cache.lookup(url: url))
+        XCTAssertEqual(fresh.freshness, .fresh)
+
+        // 90 s later — stale.
+        instant.advance(by: 60)
+        let stale = try XCTUnwrap(cache.lookup(url: url))
+        XCTAssertEqual(stale.freshness, .stale)
+    }
+
+    // MARK: - Stale-while-revalidate
+
+    func test_staleEntry_thenStore_returnsFresh() throws {
+        let instant = MutableInstant(Date(timeIntervalSince1970: 2_000_000))
+        let clock = CacheClock(now: { instant.value })
+        let cache = try MetadataCache(baseDirectory: tempDir, clock: clock)
+        let url = URL(string: "https://api.themoviedb.org/3/trending/movie/week")!
+        try cache.store(url: url, data: Data("{\"v\":1}".utf8), ttl: 60)
+
+        // Walk past expiry → stale.
+        instant.advance(by: 120)
+        XCTAssertEqual(cache.lookup(url: url)?.freshness, .stale)
+
+        // Background fetch completes → store fresh data.
+        try cache.store(url: url, data: Data("{\"v\":2}".utf8), ttl: 60)
+        let fresh = try XCTUnwrap(cache.lookup(url: url))
+        XCTAssertEqual(fresh.freshness, .fresh)
+        XCTAssertEqual(String(data: fresh.data, encoding: .utf8), "{\"v\":2}")
+    }
+
+    // MARK: - Atomic write
+
+    func test_store_isAtomic_noStaleTmpLeftBehind() throws {
+        let cache = try MetadataCache(baseDirectory: tempDir)
+        let url = URL(string: "https://api.themoviedb.org/3/movie/1")!
+        try cache.store(url: url, data: Data("{\"id\":1}".utf8), ttl: 60)
+
+        let responses = tempDir.appendingPathComponent("responses")
+        let entries = try FileManager.default.contentsOfDirectory(at: responses,
+                                                                  includingPropertiesForKeys: nil)
+        XCTAssertFalse(entries.contains(where: { $0.pathExtension == "tmp" }))
+    }
+
+    // MARK: - Corrupt-read fallback
+
+    func test_corruptPayload_treatsAsMiss() throws {
+        let cache = try MetadataCache(baseDirectory: tempDir)
+        let url = URL(string: "https://api.themoviedb.org/3/movie/1")!
+        try cache.store(url: url, data: Data("{\"id\":1}".utf8), ttl: 60)
+
+        // Hand-corrupt the payload file.
+        let responses = tempDir.appendingPathComponent("responses")
+        let payload = try FileManager.default.contentsOfDirectory(at: responses,
+                                                                  includingPropertiesForKeys: nil)
+            .first(where: { $0.pathExtension == "json" })!
+        try Data("not-valid-json".utf8).write(to: payload)
+
+        XCTAssertNil(cache.lookup(url: url), "Corrupt payload should be treated as cache-miss.")
+    }
+
+    func test_corruptPayload_isPurgedOnNextLookup() throws {
+        let cache = try MetadataCache(baseDirectory: tempDir)
+        let url = URL(string: "https://api.themoviedb.org/3/movie/1")!
+        try cache.store(url: url, data: Data("{\"id\":1}".utf8), ttl: 60)
+
+        let responses = tempDir.appendingPathComponent("responses")
+        let payload = try FileManager.default.contentsOfDirectory(at: responses,
+                                                                  includingPropertiesForKeys: nil)
+            .first(where: { $0.pathExtension == "json" })!
+        try Data("garbage".utf8).write(to: payload)
+
+        _ = cache.lookup(url: url)
+        // After purge, the response file should be gone.
+        let after = try FileManager.default.contentsOfDirectory(at: responses,
+                                                                includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "json" }
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    // MARK: - ETag round-trip
+
+    func test_etag_isPersistedAndReturnedByLookup() throws {
+        let cache = try MetadataCache(baseDirectory: tempDir)
+        let url = URL(string: "https://api.themoviedb.org/3/movie/1668")!
+        try cache.store(url: url,
+                        data: Data("{\"id\":1668}".utf8),
+                        ttl: 60,
+                        etag: "\"abc123\"",
+                        lastModified: "Thu, 01 Jan 2026 00:00:00 GMT")
+
+        let hit = try XCTUnwrap(cache.lookup(url: url))
+        XCTAssertEqual(hit.meta.etag, "\"abc123\"")
+        XCTAssertEqual(hit.meta.lastModified, "Thu, 01 Jan 2026 00:00:00 GMT")
+    }
+
+    func test_etag_persistsAcrossCacheReinstantiation() throws {
+        let url = URL(string: "https://api.themoviedb.org/3/movie/1668")!
+        do {
+            let cache = try MetadataCache(baseDirectory: tempDir)
+            try cache.store(url: url,
+                            data: Data("{\"id\":1668}".utf8),
+                            ttl: 60,
+                            etag: "\"def456\"")
+        }
+
+        let cache2 = try MetadataCache(baseDirectory: tempDir)
+        let hit = try XCTUnwrap(cache2.lookup(url: url))
+        XCTAssertEqual(hit.meta.etag, "\"def456\"")
+    }
+
+    func test_touch_updatesTTLWithoutRewritingPayload() throws {
+        let instant = MutableInstant(Date(timeIntervalSince1970: 3_000_000))
+        let clock = CacheClock(now: { instant.value })
+        let cache = try MetadataCache(baseDirectory: tempDir, clock: clock)
+        let url = URL(string: "https://api.themoviedb.org/3/movie/1")!
+        try cache.store(url: url, data: Data("{\"v\":1}".utf8), ttl: 60, etag: "\"old\"")
+
+        // Walk past expiry → stale.
+        instant.advance(by: 120)
+        XCTAssertEqual(cache.lookup(url: url)?.freshness, .stale)
+
+        // Server says 304 Not Modified — touch with new TTL + same etag.
+        cache.touch(url: url, ttl: 60, etag: "\"old\"")
+        let hit = try XCTUnwrap(cache.lookup(url: url))
+        XCTAssertEqual(hit.freshness, .fresh)
+        XCTAssertEqual(String(data: hit.data, encoding: .utf8), "{\"v\":1}",
+                       "Payload should be unchanged after touch.")
+    }
+
+    // MARK: - clearAll
+
+    func test_clearAll_removesEverything() throws {
+        let cache = try MetadataCache(baseDirectory: tempDir)
+        let url = URL(string: "https://example.com/x")!
+        try cache.store(url: url, data: Data("{\"a\":1}".utf8), ttl: 60)
+        try cache.clearAll()
+        XCTAssertNil(cache.lookup(url: url))
+    }
+}
+
+/// Sendable mutable date for `CacheClock` injection in tests.
+final class MutableInstant: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Date
+
+    init(_ initial: Date) { self._value = initial }
+
+    var value: Date {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.lock(); defer { lock.unlock() }
+        _value = _value.addingTimeInterval(seconds)
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/MetadataProviderContractTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/MetadataProviderContractTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import MetadataDomain
+
+/// Protocol-level contract suite that any `MetadataProvider` impl must
+/// satisfy. Run against `FakeMetadataProvider` in CI; the live-TMDB
+/// integration suite is gated behind `TMDB_LIVE_TESTS=1` and never runs
+/// in CI (no embedded keys).
+///
+/// Subclasses override `makeProvider()` to plug in different impls.
+class MetadataProviderContractTests: XCTestCase {
+
+    func makeProvider() -> MetadataProvider { FakeMetadataProvider() }
+
+    // MARK: - Trending / popular / top-rated
+
+    func test_trending_movieWeek_returnsMediaItems() async throws {
+        let provider = makeProvider()
+        let items = try await provider.trending(media: .movie, window: .week)
+        XCTAssertFalse(items.isEmpty)
+    }
+
+    func test_trending_tvDay_returnsMediaItems() async throws {
+        let provider = makeProvider()
+        let items = try await provider.trending(media: .tv, window: .day)
+        XCTAssertFalse(items.isEmpty)
+    }
+
+    func test_popular_movies_returnsMovieItems() async throws {
+        let provider = makeProvider()
+        let items = try await provider.popular(media: .movie)
+        for item in items {
+            if case .movie = item { continue }
+            XCTFail("popular(.movie) returned a non-movie item: \(item)")
+        }
+    }
+
+    func test_popular_tv_returnsShowItems() async throws {
+        let provider = makeProvider()
+        let items = try await provider.popular(media: .tv)
+        for item in items {
+            if case .show = item { continue }
+            XCTFail("popular(.tv) returned a non-show item: \(item)")
+        }
+    }
+
+    func test_topRated_movies_returnsMovieItems() async throws {
+        let provider = makeProvider()
+        let items = try await provider.topRated(media: .movie)
+        for item in items {
+            if case .movie = item { continue }
+            XCTFail("topRated(.movie) returned a non-movie item: \(item)")
+        }
+    }
+
+    // MARK: - Search
+
+    func test_searchMulti_emptyQuery_doesNotCrash() async throws {
+        let provider = makeProvider()
+        _ = try await provider.searchMulti(query: "")
+    }
+
+    func test_searchMulti_returnsMediaItems() async throws {
+        let provider = makeProvider()
+        let items = try await provider.searchMulti(query: "matrix")
+        XCTAssertFalse(items.isEmpty)
+    }
+
+    // MARK: - Detail
+
+    func test_movieDetail_byID_returnsMatchingMovie() async throws {
+        let provider = makeProvider()
+        let id = MediaID(provider: .tmdb, id: 27205)
+        let movie = try await provider.movieDetail(id: id)
+        XCTAssertEqual(movie.id, id)
+    }
+
+    func test_showDetail_byID_returnsMatchingShow() async throws {
+        let provider = makeProvider()
+        let id = MediaID(provider: .tmdb, id: 1399)
+        let show = try await provider.showDetail(id: id)
+        XCTAssertEqual(show.id, id)
+    }
+
+    func test_seasonDetail_byShowAndSeason_returnsCorrectSeason() async throws {
+        let provider = makeProvider()
+        let showID = MediaID(provider: .tmdb, id: 1399)
+        let season = try await provider.seasonDetail(showID: showID, season: 1)
+        XCTAssertEqual(season.showID, showID)
+        XCTAssertEqual(season.seasonNumber, 1)
+    }
+
+    // MARK: - Recommendations
+
+    func test_recommendations_returnsMediaItems() async throws {
+        let provider = makeProvider()
+        let id = MediaID(provider: .tmdb, id: 27205)
+        let items = try await provider.recommendations(for: id)
+        XCTAssertFalse(items.isEmpty)
+    }
+
+    // MARK: - Image URL
+
+    func test_imageURL_includesSizeAndPath() {
+        let provider = makeProvider()
+        let url = provider.imageURL(path: "/abc.jpg", size: .w342)
+        XCTAssertTrue(url.absoluteString.contains("w342"))
+        XCTAssertTrue(url.absoluteString.hasSuffix("abc.jpg"))
+    }
+
+    func test_imageURL_handlesPathWithoutLeadingSlash() {
+        let provider = makeProvider()
+        let url = provider.imageURL(path: "abc.jpg", size: .w500)
+        XCTAssertTrue(url.absoluteString.contains("w500"))
+        XCTAssertFalse(url.absoluteString.contains("//abc"))
+    }
+
+    func test_imageURL_isPureFunction() {
+        let provider = makeProvider()
+        let a = provider.imageURL(path: "/x.jpg", size: .w1280)
+        let b = provider.imageURL(path: "/x.jpg", size: .w1280)
+        XCTAssertEqual(a, b)
+    }
+}
+
+/// Concrete invocation of the contract suite against `FakeMetadataProvider`.
+/// (Subclassing is enough for XCTest to discover the parent's tests, but
+/// exposing a named subclass makes the run output unambiguous.)
+final class FakeMetadataProviderContractTests: MetadataProviderContractTests {
+    override func makeProvider() -> MetadataProvider { FakeMetadataProvider() }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/Support/FakeMetadataProvider.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/Support/FakeMetadataProvider.swift
@@ -1,0 +1,137 @@
+import Foundation
+@testable import MetadataDomain
+
+/// Test-only `MetadataProvider` impl that returns canned responses from
+/// pre-baked Swift fixtures. Lives under `Tests/MetadataDomainTests/Support/`
+/// so any consumer test can substitute it without a network call.
+///
+/// Behaviour notes:
+/// - Each method has an injectable `closure` so tests can return per-call
+///   shaped responses; the default returns the standard fixture.
+/// - `imageURL(path:size:)` is pure and uses the same shape as
+///   `TMDBProvider.imageURL` so contract tests cover both impls.
+public final class FakeMetadataProvider: MetadataProvider, @unchecked Sendable {
+
+    public init() {}
+
+    public var trendingHandler: (@Sendable (TrendingMedia, TrendingWindow) async throws -> [MediaItem])?
+    public var popularHandler: (@Sendable (TrendingMedia) async throws -> [MediaItem])?
+    public var topRatedHandler: (@Sendable (TrendingMedia) async throws -> [MediaItem])?
+    public var searchMultiHandler: (@Sendable (String) async throws -> [MediaItem])?
+    public var movieDetailHandler: (@Sendable (MediaID) async throws -> Movie)?
+    public var showDetailHandler: (@Sendable (MediaID) async throws -> Show)?
+    public var seasonDetailHandler: (@Sendable (MediaID, Int) async throws -> Season)?
+    public var recommendationsHandler: (@Sendable (MediaID) async throws -> [MediaItem])?
+
+    public func trending(media: TrendingMedia, window: TrendingWindow) async throws -> [MediaItem] {
+        if let h = trendingHandler { return try await h(media, window) }
+        return [Self.canonicalMovie(), Self.canonicalShow()]
+    }
+
+    public func popular(media: TrendingMedia) async throws -> [MediaItem] {
+        if let h = popularHandler { return try await h(media) }
+        switch media {
+        case .movie: return [Self.canonicalMovie()]
+        case .tv: return [Self.canonicalShow()]
+        case .all: return [Self.canonicalMovie(), Self.canonicalShow()]
+        }
+    }
+
+    public func topRated(media: TrendingMedia) async throws -> [MediaItem] {
+        if let h = topRatedHandler { return try await h(media) }
+        switch media {
+        case .movie: return [Self.canonicalMovie()]
+        case .tv: return [Self.canonicalShow()]
+        case .all: return [Self.canonicalMovie(), Self.canonicalShow()]
+        }
+    }
+
+    public func searchMulti(query: String) async throws -> [MediaItem] {
+        if let h = searchMultiHandler { return try await h(query) }
+        // Fixed canned response for search; tests inspect the query as needed.
+        return [Self.canonicalMovie()]
+    }
+
+    public func movieDetail(id: MediaID) async throws -> Movie {
+        if let h = movieDetailHandler { return try await h(id) }
+        return Self.canonicalMovieStruct(id: id)
+    }
+
+    public func showDetail(id: MediaID) async throws -> Show {
+        if let h = showDetailHandler { return try await h(id) }
+        return Self.canonicalShowStruct(id: id)
+    }
+
+    public func seasonDetail(showID: MediaID, season: Int) async throws -> Season {
+        if let h = seasonDetailHandler { return try await h(showID, season) }
+        return Self.canonicalSeasonStruct(showID: showID, season: season)
+    }
+
+    public func recommendations(for id: MediaID) async throws -> [MediaItem] {
+        if let h = recommendationsHandler { return try await h(id) }
+        return [Self.canonicalMovie()]
+    }
+
+    public func imageURL(path: String, size: TMDBImageSize) -> URL {
+        let trimmed = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        return URL(string: "https://image.tmdb.org/t/p")!
+            .appendingPathComponent(size.rawValue)
+            .appendingPathComponent(trimmed)
+    }
+
+    // MARK: - Canned fixtures
+
+    public static func canonicalMovie() -> MediaItem { .movie(canonicalMovieStruct()) }
+    public static func canonicalShow() -> MediaItem { .show(canonicalShowStruct()) }
+
+    public static func canonicalMovieStruct(id: MediaID = MediaID(provider: .tmdb, id: 27205)) -> Movie {
+        Movie(id: id,
+              title: "Inception",
+              originalTitle: "Inception",
+              releaseYear: 2010,
+              runtimeMinutes: 148,
+              overview: "A thief who steals corporate secrets.",
+              genres: [Genre(id: 28, name: "Action"), Genre(id: 878, name: "Science Fiction")],
+              posterPath: "/inception.jpg",
+              backdropPath: "/inception_back.jpg",
+              voteAverage: 8.4,
+              popularity: 100.0)
+    }
+
+    public static func canonicalShowStruct(id: MediaID = MediaID(provider: .tmdb, id: 1399)) -> Show {
+        Show(id: id,
+             name: "Game of Thrones",
+             originalName: "Game of Thrones",
+             firstAirYear: 2011,
+             lastAirYear: 2019,
+             status: .ended,
+             overview: "Seven noble families fight for control.",
+             genres: [Genre(id: 18, name: "Drama")],
+             posterPath: "/got.jpg",
+             backdropPath: "/got_back.jpg",
+             voteAverage: 8.4,
+             popularity: 200.0,
+             seasons: [])
+    }
+
+    public static func canonicalSeasonStruct(showID: MediaID = MediaID(provider: .tmdb, id: 1399),
+                                             season: Int = 1) -> Season {
+        Season(showID: showID,
+               seasonNumber: season,
+               name: "Season \(season)",
+               overview: "The first season.",
+               posterPath: "/got_s1.jpg",
+               airDate: nil,
+               episodes: [
+                Episode(id: MediaID(provider: .tmdb, id: 63056),
+                        showID: showID,
+                        seasonNumber: season,
+                        episodeNumber: 1,
+                        name: "Winter Is Coming",
+                        overview: "Eddard Stark.",
+                        stillPath: "/s1e1.jpg",
+                        runtimeMinutes: 62,
+                        airDate: nil)
+               ])
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/TMDBProviderTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/TMDBProviderTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import MetadataDomain
+
+/// Pure tests for `TMDBProvider`'s URL construction and DTO decoding.
+/// Does not exercise the network. The live integration suite is gated by
+/// `TMDB_LIVE_TESTS` and not run in CI.
+final class TMDBProviderTests: XCTestCase {
+
+    // MARK: - imageURL
+
+    func test_imageURL_buildsTMDBPath() async {
+        let provider = makeProvider()
+        let url = await provider.imageURL(path: "/inception.jpg", size: .w500)
+        XCTAssertEqual(url.absoluteString,
+                       "https://image.tmdb.org/t/p/w500/inception.jpg")
+    }
+
+    func test_imageURL_stripsLeadingSlash() async {
+        let provider = makeProvider()
+        let url = await provider.imageURL(path: "abc.jpg", size: .w342)
+        XCTAssertFalse(url.absoluteString.contains("//abc"))
+    }
+
+    // MARK: - DTO decoding
+
+    func test_movieDetailDTO_decodesAndMapsToMovie() throws {
+        let json = """
+        {
+          "id": 27205,
+          "title": "Inception",
+          "original_title": "Inception",
+          "release_date": "2010-07-16",
+          "runtime": 148,
+          "overview": "A thief...",
+          "poster_path": "/inception.jpg",
+          "backdrop_path": "/back.jpg",
+          "vote_average": 8.4,
+          "popularity": 100.0,
+          "genres": [{"id": 28, "name": "Action"}]
+        }
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(MovieDetailDTO.self, from: json)
+        let movie = dto.toMovie()
+        XCTAssertEqual(movie.id, MediaID(provider: .tmdb, id: 27205))
+        XCTAssertEqual(movie.title, "Inception")
+        XCTAssertEqual(movie.releaseYear, 2010)
+        XCTAssertEqual(movie.runtimeMinutes, 148)
+        XCTAssertEqual(movie.genres.first?.name, "Action")
+    }
+
+    func test_showDetailDTO_decodesAndMapsToShow() throws {
+        let json = """
+        {
+          "id": 1399,
+          "name": "Game of Thrones",
+          "original_name": "Game of Thrones",
+          "first_air_date": "2011-04-17",
+          "last_air_date": "2019-05-19",
+          "status": "Ended",
+          "in_production": false,
+          "overview": "Seven noble families...",
+          "poster_path": "/got.jpg",
+          "backdrop_path": "/back.jpg",
+          "vote_average": 8.4,
+          "popularity": 200.0,
+          "genres": [{"id": 18, "name": "Drama"}],
+          "seasons": [
+            {"season_number": 1, "name": "Season 1", "overview": "", "poster_path": "/s1.jpg"}
+          ]
+        }
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(ShowDetailDTO.self, from: json)
+        let show = dto.toShow()
+        XCTAssertEqual(show.id, MediaID(provider: .tmdb, id: 1399))
+        XCTAssertEqual(show.firstAirYear, 2011)
+        XCTAssertEqual(show.lastAirYear, 2019)
+        XCTAssertEqual(show.status, .ended)
+        XCTAssertEqual(show.seasons.count, 1)
+        XCTAssertEqual(show.seasons.first?.seasonNumber, 1)
+    }
+
+    func test_trendingItemDTO_movie_mapsToMovieMediaItem() throws {
+        let json = """
+        {
+          "media_type": "movie",
+          "id": 1,
+          "title": "Title",
+          "original_title": "Title",
+          "release_date": "2020-01-01",
+          "overview": "x",
+          "poster_path": "/p.jpg",
+          "backdrop_path": "/b.jpg",
+          "vote_average": 7.0,
+          "popularity": 50.0,
+          "genre_ids": [28]
+        }
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(TrendingItemDTO.self, from: json)
+        let item = dto.toMediaItem()
+        switch item {
+        case .movie(let m): XCTAssertEqual(m.id.id, 1)
+        default: XCTFail("Expected movie")
+        }
+    }
+
+    func test_trendingItemDTO_tv_mapsToShowMediaItem() throws {
+        let json = """
+        {
+          "media_type": "tv",
+          "id": 2,
+          "name": "Show",
+          "original_name": "Show",
+          "first_air_date": "2018-09-25",
+          "overview": "y",
+          "poster_path": "/p.jpg",
+          "backdrop_path": "/b.jpg",
+          "vote_average": 7.5,
+          "popularity": 60.0,
+          "genre_ids": [18]
+        }
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(TrendingItemDTO.self, from: json)
+        let item = dto.toMediaItem()
+        switch item {
+        case .show(let s): XCTAssertEqual(s.id.id, 2)
+        default: XCTFail("Expected show")
+        }
+    }
+
+    func test_trendingItemDTO_person_mapsToNil() throws {
+        let json = """
+        {"media_type": "person", "id": 3, "name": "Actor"}
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(TrendingItemDTO.self, from: json)
+        XCTAssertNil(dto.toMediaItem())
+    }
+
+    func test_seasonDetailDTO_mapsEpisodes() throws {
+        let json = """
+        {
+          "season_number": 1,
+          "name": "Season 1",
+          "overview": "",
+          "poster_path": "/p.jpg",
+          "air_date": "2011-04-17",
+          "episodes": [
+            {
+              "id": 100,
+              "season_number": 1,
+              "episode_number": 1,
+              "name": "Pilot",
+              "overview": "",
+              "still_path": "/s.jpg",
+              "runtime": 60,
+              "air_date": "2011-04-17"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(SeasonDetailDTO.self, from: json)
+        let showID = MediaID(provider: .tmdb, id: 1399)
+        let season = dto.toSeason(showID: showID)
+        XCTAssertEqual(season.episodes.count, 1)
+        XCTAssertEqual(season.episodes[0].episodeNumber, 1)
+        XCTAssertEqual(season.episodes[0].showID, showID)
+    }
+
+    // MARK: - Helpers
+
+    private func makeProvider() -> TMDBProvider {
+        TMDBProvider(config: .init(bearerToken: ""))
+    }
+}

--- a/Packages/MetadataDomain/Tests/MetadataDomainTests/TitleNameParserTests.swift
+++ b/Packages/MetadataDomain/Tests/MetadataDomainTests/TitleNameParserTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import MetadataDomain
+
+final class TitleNameParserTests: XCTestCase {
+
+    // MARK: - Fixture-driven coverage (≥ 50 cases)
+
+    func test_allFixtures_parseToExpected() throws {
+        let fixtures = try Self.loadFixtures()
+        XCTAssertGreaterThanOrEqual(fixtures.count, 50,
+                                    "Need at least 50 fixture cases per design § Test shape.")
+
+        var failures: [String] = []
+        for (input, expected) in fixtures {
+            let actual = TitleNameParser.parse(input)
+            if !Self.matches(actual: actual, expected: expected) {
+                failures.append(
+                    "\nInput: \(input)\n  expected: \(expected)\n  actual:   \(Self.describe(actual))"
+                )
+            }
+        }
+        if !failures.isEmpty {
+            XCTFail("Parser fixture mismatches (\(failures.count)):\n" + failures.joined())
+        }
+    }
+
+    // MARK: - Targeted unit tests for specific shapes
+
+    func test_movie_dotSeparated_extractsTitleAndYear() {
+        let p = TitleNameParser.parse("The.Matrix.1999.1080p.BluRay.x264-GROUP.mkv")
+        XCTAssertEqual(p.title, "The Matrix")
+        XCTAssertEqual(p.year, 1999)
+        XCTAssertNil(p.season)
+        XCTAssertNil(p.episode)
+        XCTAssertEqual(p.releaseGroup, "GROUP")
+        XCTAssertTrue(p.qualityHints.contains(.p1080))
+        XCTAssertTrue(p.qualityHints.contains(.bluRay))
+        XCTAssertTrue(p.qualityHints.contains(.x264))
+    }
+
+    func test_show_seasonEpisodeMarker_extractsBoth() {
+        let p = TitleNameParser.parse("Friends.S01E01.The.One.Where.Monica.Gets.A.Roommate.1080p.BluRay.x264-PSYCHD.mkv")
+        XCTAssertEqual(p.title, "Friends")
+        XCTAssertEqual(p.season, 1)
+        XCTAssertEqual(p.episode, 1)
+        XCTAssertNil(p.year)
+        XCTAssertEqual(p.releaseGroup, "PSYCHD")
+    }
+
+    func test_anime_bracketGroup_dashEpisode_assignsSeasonOne() {
+        let p = TitleNameParser.parse("[SubsPlease] Spy x Family - 12 (1080p) [ABCDEF12].mkv")
+        XCTAssertEqual(p.title, "Spy x Family")
+        XCTAssertEqual(p.season, 1)
+        XCTAssertEqual(p.episode, 12)
+        XCTAssertEqual(p.releaseGroup, "SubsPlease")
+        XCTAssertTrue(p.qualityHints.contains(.p1080))
+    }
+
+    func test_romanNumeralSequel_isPreservedInTitle() {
+        let p = TitleNameParser.parse("Rocky.II.1979.1080p.BluRay.x264-AMIABLE.mkv")
+        XCTAssertEqual(p.title, "Rocky II")
+        XCTAssertEqual(p.year, 1979)
+    }
+
+    func test_arabicNumeralSequel_isPreservedInTitle() {
+        let p = TitleNameParser.parse("Rocky.2.1979.1080p.BluRay.x264-FAKE.mkv")
+        XCTAssertEqual(p.title, "Rocky 2")
+        XCTAssertEqual(p.year, 1979)
+    }
+
+    func test_seasonOnlyMarker_seasonSetEpisodeNil() {
+        let p = TitleNameParser.parse("Westworld.Season.1.Complete.1080p.BluRay.x264-DEFLATE.mkv")
+        XCTAssertEqual(p.season, 1)
+        XCTAssertNil(p.episode)
+    }
+
+    func test_qualityHints_remuxAndHDR_detected() {
+        let p = TitleNameParser.parse("Avatar.The.Way.of.Water.2022.2160p.UHD.BluRay.x265.10bit.HDR-TERMINAL.mkv")
+        XCTAssertTrue(p.qualityHints.contains(.p2160))
+        XCTAssertTrue(p.qualityHints.contains(.hdr))
+        XCTAssertTrue(p.qualityHints.contains(.bluRay))
+        XCTAssertTrue(p.qualityHints.contains(.x265))
+        XCTAssertTrue(p.qualityHints.contains(.uhd))
+    }
+
+    func test_unknownExtension_keepsExtensionInName() {
+        // Defensive: weird extension shouldn't crash; title still extracted.
+        let p = TitleNameParser.parse("Some.Movie.2010.bin")
+        XCTAssertEqual(p.year, 2010)
+    }
+
+    func test_emptyString_returnsEmptyTitle() {
+        let p = TitleNameParser.parse("")
+        XCTAssertEqual(p.title, "")
+        XCTAssertNil(p.year)
+        XCTAssertNil(p.season)
+        XCTAssertNil(p.episode)
+    }
+
+    // MARK: - Fixture loading
+
+    struct ExpectedParse: Codable {
+        let title: String
+        let year: Int?
+        let season: Int?
+        let episode: Int?
+        let releaseGroup: String?
+        let qualityHints: [String]
+    }
+
+    static func loadFixtures() throws -> [(String, ExpectedParse)] {
+        let jsonURL = try XCTUnwrap(
+            Bundle.module.url(forResource: "release-names",
+                              withExtension: "json",
+                              subdirectory: "Fixtures")
+            ?? Bundle.module.url(forResource: "release-names.expected",
+                                 withExtension: "json",
+                                 subdirectory: "Fixtures")
+        )
+        let data = try Data(contentsOf: jsonURL)
+        let dict = try JSONDecoder().decode([String: ExpectedParse].self, from: data)
+
+        let txtURL = try XCTUnwrap(
+            Bundle.module.url(forResource: "release-names",
+                              withExtension: "txt",
+                              subdirectory: "Fixtures")
+        )
+        let lines = try String(contentsOf: txtURL, encoding: .utf8)
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+            .filter { !$0.hasPrefix("#") && !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+
+        // Preserve order from the text file so failures are easier to triage.
+        return try lines.map { line in
+            let expected = try XCTUnwrap(dict[line], "Missing expected entry for: \(line)")
+            return (line, expected)
+        }
+    }
+
+    static func matches(actual: ParsedTitle, expected: ExpectedParse) -> Bool {
+        let actualHints = Set(actual.qualityHints.map(\.rawValue))
+        let expectedHints = Set(expected.qualityHints)
+        return actual.title == expected.title
+            && actual.year == expected.year
+            && actual.season == expected.season
+            && actual.episode == expected.episode
+            && actual.releaseGroup == expected.releaseGroup
+            && actualHints == expectedHints
+    }
+
+    static func describe(_ p: ParsedTitle) -> String {
+        let hints = p.qualityHints.map(\.rawValue).sorted().joined(separator: ",")
+        return "title=\(p.title) year=\(String(describing: p.year)) " +
+               "S=\(String(describing: p.season)) E=\(String(describing: p.episode)) " +
+               "group=\(String(describing: p.releaseGroup)) hints=[\(hints)]"
+    }
+}


### PR DESCRIPTION
Foundation package for Phase 4 discovery + metadata work.

## Scope
Pure-Swift `Packages/MetadataDomain/` package per `docs/design/discovery-metadata-foundation.md`:

- `MediaItem = .movie(Movie) | .show(Show)` discriminated union with Episode first-class
- `TitleNameParser` + `MatchRanker` pure helpers for "torrent filename → TMDB candidate" seam (powers #17 continue-watching)
- `MetadataProvider` protocol + `TMDBProvider` implementation (v3 REST, hand-rolled URLSession, no SDK dep)
- `MetadataCache` on-disk JSON cache with TTL
- `TMDBImageSizes` helpers for URLCache-backed image loading

## Tests
96 unit tests covering: parser fixtures (63 release names × expected parse), match ranker, provider contract, cache round-trip + TTL, Codable stability of MediaItem.

Zero `.pbxproj` changes (pure SPM package, wired into the App target in the first consuming ticket per design D4).

Closes #11. Refs #2.