### PR TITLE
feat(player): end-of-episode detector (epic #3 phase 3 tail, #20)

### DIFF
--- a/App/Features/Player/EndOfEpisodeDetector.swift
+++ b/App/Features/Player/EndOfEpisodeDetector.swift
@@ -1,0 +1,82 @@
+import Combine
+import Foundation
+import MetadataDomain
+import PlayerDomain
+
+// MARK: - EndOfEpisodeSignal
+
+/// Emitted by `EndOfEpisodeDetector` when an episode reaches its natural end.
+/// Consumed by #21 (next-episode auto-play with grace period).
+public struct EndOfEpisodeSignal: Equatable, Sendable {
+    public let episode: Episode
+
+    public init(episode: Episode) {
+        self.episode = episode
+    }
+}
+
+// MARK: - EndOfEpisodeDetector
+//
+// Pure detector that observes `PlayerState` transitions plus episode metadata
+// and emits an `EndOfEpisodeSignal` when an episode reaches its natural end.
+//
+// Per the issue #20 AC and `docs/design/player-state-foundation.md § Out of
+// scope`, this is a sibling observer of `PlayerState`, not a new state in
+// the foundation. The detector does not write watch state — Phase 1's
+// `CacheManager` byte-threshold path owns that (spec 05 rev 5, addendum A26).
+//
+// Trigger (all must hold):
+//   1. The transition is `.playing → .closed`.
+//   2. The asset is identified as an `Episode` (`episode != nil`).
+//   3. Playhead is within `threshold` seconds of asset end.
+//
+// The publisher hook below lets #21 subscribe; for now it is unwired.
+
+public enum EndOfEpisodeDetector {
+
+    /// Default threshold: how close to the asset's end a `.playing → .closed`
+    /// edge must be to count as a natural episode end. 30 s is permissive
+    /// enough to absorb credit-roll variance for typical scripted TV.
+    public static let defaultThresholdSeconds: Double = 30
+
+    /// Pure decision function. Returns a non-nil signal iff the inputs match
+    /// the trigger conditions documented above.
+    ///
+    /// - Parameters:
+    ///   - stateTransition: `(from, to)` pair from the `PlayerState` machine.
+    ///   - playheadSeconds: Current playhead in seconds at the moment of the
+    ///     transition.
+    ///   - durationSeconds: Asset duration in seconds. Must be `> 0`.
+    ///   - episode: The `Episode` this asset represents, or `nil` if the
+    ///     asset is a movie / unknown / extras.
+    ///   - threshold: Tunable proximity-to-end window. Defaults to
+    ///     `defaultThresholdSeconds`.
+    public static func detect(
+        stateTransition: (from: PlayerState, to: PlayerState),
+        playheadSeconds: Double,
+        durationSeconds: Double,
+        episode: Episode?,
+        threshold: Double = defaultThresholdSeconds
+    ) -> EndOfEpisodeSignal? {
+        guard let episode else { return nil }
+        guard stateTransition.from == .playing, stateTransition.to == .closed else {
+            return nil
+        }
+        guard durationSeconds > 0 else { return nil }
+        let remaining = durationSeconds - playheadSeconds
+        guard remaining <= threshold else { return nil }
+        return EndOfEpisodeSignal(episode: episode)
+    }
+
+    // MARK: - Telemetry hook
+    //
+    // Shared `PassthroughSubject` for #21's consumer to subscribe to. The
+    // detector itself stays pure; whoever drives state transitions calls
+    // `detect(...)` and forwards a non-nil result through `publisher.send(_:)`.
+
+    /// Subscribe to receive `EndOfEpisodeSignal` events as the
+    /// `PlayerViewModel` (or another driver) projects them. `PassthroughSubject`
+    /// is internally thread-safe; the `nonisolated(unsafe)` opt-out lets the
+    /// shared instance live as a static `let` under Swift 6 strict concurrency.
+    nonisolated(unsafe) public static let publisher = PassthroughSubject<EndOfEpisodeSignal, Never>()
+}

--- a/ButterBar.xcodeproj/project.pbxproj
+++ b/ButterBar.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		AA11BB33CC55DD77EE99FF11 /* EngineStore in Frameworks */ = {isa = PBXBuildFile; productRef = FF66AA88BB00CC22DD44EE66 /* EngineStore */; };
 		FACE0001AAAA0000BBBB0001 /* LibraryDomain in Frameworks */ = {isa = PBXBuildFile; productRef = FACE0004AAAA0000BBBB0004 /* LibraryDomain */; };
 		B11E0001000000000000BB01 /* PlayerDomain in Frameworks */ = {isa = PBXBuildFile; productRef = B11E0004000000000000BB04 /* PlayerDomain */; };
+		EOE0000100000000000000A1 /* MetadataDomain in Frameworks */ = {isa = PBXBuildFile; productRef = EOE0000400000000000000A4 /* MetadataDomain */; };
+		EOE0000500000000000000A5 /* MetadataDomain in Frameworks */ = {isa = PBXBuildFile; productRef = EOE0000600000000000000A6 /* MetadataDomain */; };
+		EOE0000700000000000000A7 /* EndOfEpisodeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EOE0000800000000000000A8 /* EndOfEpisodeDetector.swift */; };
+		EOE0000900000000000000A9 /* EndOfEpisodeDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EOE0000A00000000000000AA /* EndOfEpisodeDetectorTests.swift */; };
 		AA33BB55CC77DD99EE11FF33 /* ResumeTrackerSelfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6600889900AABB11CC2233 /* ResumeTrackerSelfTest.swift */; };
 		AA77889900BBCCDD11AA7788 /* HTTPSelfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8899AA00CCDDEE22BB8899 /* HTTPSelfTest.swift */; };
 		B5C7D9E1F3A2048A67B9C0D1 /* TorrentBridgeSmokeTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = F8C1D5A3B2E497640F3A5B02 /* TorrentBridgeSmokeTest.mm */; };
@@ -184,6 +188,9 @@
 		DD44EE66FF88AA00BB22CC44 /* EngineStore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = EngineStore; path = Packages/EngineStore; sourceTree = "<group>"; };
 		FACE0002AAAA0000BBBB0002 /* LibraryDomain */ = {isa = PBXFileReference; lastKnownFileType = folder; name = LibraryDomain; path = Packages/LibraryDomain; sourceTree = "<group>"; };
 		B11E0002000000000000BB02 /* PlayerDomain */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PlayerDomain; path = Packages/PlayerDomain; sourceTree = "<group>"; };
+		EOE0000200000000000000A2 /* MetadataDomain */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MetadataDomain; path = Packages/MetadataDomain; sourceTree = "<group>"; };
+		EOE0000800000000000000A8 /* EndOfEpisodeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfEpisodeDetector.swift; sourceTree = "<group>"; };
+		EOE0000A00000000000000AA /* EndOfEpisodeDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfEpisodeDetectorTests.swift; sourceTree = "<group>"; };
 		E1000002000000000000EE02 /* CacheEvictionProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheEvictionProbe.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E1F2A3B4C5D6 /* ByteReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteReader.swift; sourceTree = "<group>"; };
 		E2000002000000000000EE02 /* CacheEviction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheEviction.swift; sourceTree = "<group>"; };
@@ -215,6 +222,7 @@
 				97D6C5379559B125DE089050 /* PlannerCore in Frameworks */,
 				FACE0001AAAA0000BBBB0001 /* LibraryDomain in Frameworks */,
 				B11E0001000000000000BB01 /* PlayerDomain in Frameworks */,
+				EOE0000100000000000000A1 /* MetadataDomain in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -234,6 +242,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8E4F6EAC342FC231B7B08716 /* SnapshotTesting in Frameworks */,
+				EOE0000500000000000000A5 /* MetadataDomain in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -293,6 +302,7 @@
 				RP1000003000000000BB03 /* ResumePromptDecisionTests.swift */,
 				RP1000004000000000BB04 /* PlayerViewModelResumePromptTests.swift */,
 				RP1000005000000000BB05 /* ResumePromptSnapshotTests.swift */,
+				EOE0000A00000000000000AA /* EndOfEpisodeDetectorTests.swift */,
 			);
 			path = ButterBarTests;
 			sourceTree = "<group>";
@@ -412,6 +422,7 @@
 				B1000008000000000000BB08 /* PlayerScrubBar.swift */,
 				RP1000001000000000BB01 /* ResumePromptDecision.swift */,
 				RP1000002000000000BB02 /* ResumePromptView.swift */,
+				EOE0000800000000000000A8 /* EndOfEpisodeDetector.swift */,
 			);
 			path = Player;
 			sourceTree = "<group>";
@@ -435,6 +446,7 @@
 				DD44EE66FF88AA00BB22CC44 /* EngineStore */,
 				FACE0002AAAA0000BBBB0002 /* LibraryDomain */,
 				B11E0002000000000000BB02 /* PlayerDomain */,
+				EOE0000200000000000000A2 /* MetadataDomain */,
 			);
 			name = Packages;
 			sourceTree = "<group>";
@@ -496,6 +508,7 @@
 				BDA7E17795E9B0C29D6E029A /* PlannerCore */,
 				FACE0004AAAA0000BBBB0004 /* LibraryDomain */,
 				B11E0004000000000000BB04 /* PlayerDomain */,
+				EOE0000400000000000000A4 /* MetadataDomain */,
 			);
 			productName = ButterBar;
 			productReference = 67921BA991E985B2A97454A8 /* ButterBar.app */;
@@ -516,6 +529,7 @@
 			name = ButterBarTests;
 			packageProductDependencies = (
 				6F770D65D670E58E0351D8AE /* SnapshotTesting */,
+				EOE0000600000000000000A6 /* MetadataDomain */,
 			);
 			productName = ButterBarTests;
 			productReference = 3A4B5C6D7E8F3A4B5C6D7E8F /* ButterBarTests.xctest */;
@@ -581,6 +595,7 @@
 				EE55FF77AA99BB11CC33DD55 /* XCLocalSwiftPackageReference "Packages/EngineStore" */,
 				FACE0003AAAA0000BBBB0003 /* XCLocalSwiftPackageReference "Packages/LibraryDomain" */,
 				B11E0003000000000000BB03 /* XCLocalSwiftPackageReference "Packages/PlayerDomain" */,
+				EOE0000300000000000000A3 /* XCLocalSwiftPackageReference "Packages/MetadataDomain" */,
 				390C8C7D7247342CD8100F2F /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 			);
 			productRefGroup = 21A59A6D24B4DEA9DB9C5973 /* Products */;
@@ -632,6 +647,7 @@
 				RP1000003000000000AA03 /* ResumePromptDecisionTests.swift in Sources */,
 				RP1000004000000000AA04 /* PlayerViewModelResumePromptTests.swift in Sources */,
 				RP1000005000000000AA05 /* ResumePromptSnapshotTests.swift in Sources */,
+				EOE0000900000000000000A9 /* EndOfEpisodeDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -698,6 +714,7 @@
 				A1000008000000000000AA08 /* PlayerScrubBar.swift in Sources */,
 				RP1000001000000000AA01 /* ResumePromptDecision.swift in Sources */,
 				RP1000002000000000AA02 /* ResumePromptView.swift in Sources */,
+				EOE0000700000000000000A7 /* EndOfEpisodeDetector.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1382,6 +1399,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/PlayerDomain;
 		};
+		EOE0000300000000000000A3 /* XCLocalSwiftPackageReference "Packages/MetadataDomain" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/MetadataDomain;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1435,6 +1456,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B11E0003000000000000BB03 /* XCLocalSwiftPackageReference "Packages/PlayerDomain" */;
 			productName = PlayerDomain;
+		};
+		EOE0000400000000000000A4 /* MetadataDomain */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EOE0000300000000000000A3 /* XCLocalSwiftPackageReference "Packages/MetadataDomain" */;
+			productName = MetadataDomain;
+		};
+		EOE0000600000000000000A6 /* MetadataDomain */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EOE0000300000000000000A3 /* XCLocalSwiftPackageReference "Packages/MetadataDomain" */;
+			productName = MetadataDomain;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/ButterBarTests/EndOfEpisodeDetectorTests.swift
+++ b/Tests/ButterBarTests/EndOfEpisodeDetectorTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+import MetadataDomain
+import PlayerDomain
+@testable import ButterBar
+
+// MARK: - EndOfEpisodeDetectorTests
+//
+// Pure tests for `EndOfEpisodeDetector.detect(...)`. The detector is a
+// sibling observer of `PlayerState` (per `docs/design/player-state-foundation.md`
+// § Out of scope) — it does not extend the state machine. The trigger is
+// `.playing → .closed` while the asset is an `Episode` and the playhead is
+// within the threshold of the asset's end. See issue #20 for the AC table.
+
+final class EndOfEpisodeDetectorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeEpisode() -> Episode {
+        Episode(
+            id: MediaID(provider: .tmdb, id: 1001),
+            showID: MediaID(provider: .tmdb, id: 42),
+            seasonNumber: 1,
+            episodeNumber: 1,
+            name: "Pilot",
+            overview: "",
+            stillPath: nil,
+            runtimeMinutes: 45,
+            airDate: nil
+        )
+    }
+
+    // MARK: - Positive: genuine episode-end fires
+
+    func testFires_whenPlayingClosesNearAssetEnd() {
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 2_695, // 5s before 45-min asset end
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertEqual(signal?.episode, episode)
+    }
+
+    func testFires_whenPlayingClosesExactlyAtAssetEnd() {
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 2_700,
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNotNil(signal)
+    }
+
+    // MARK: - Negative: movies (episode == nil)
+
+    func testDoesNotFire_forMovies() {
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 2_695,
+            durationSeconds: 2_700,
+            episode: nil
+        )
+        XCTAssertNil(signal)
+    }
+
+    // MARK: - Negative: user mid-episode close
+
+    func testDoesNotFire_onUserMidEpisodeClose() {
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 600, // 10 minutes in, far from end
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNil(signal)
+    }
+
+    // MARK: - Negative: error transition
+
+    func testDoesNotFire_onErrorTransition() {
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .error(.playbackFailed)),
+            playheadSeconds: 2_695,
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNil(signal)
+    }
+
+    // MARK: - Negative: paused transition
+
+    func testDoesNotFire_onPlayingToPaused() {
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .paused),
+            playheadSeconds: 2_695,
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNil(signal)
+    }
+
+    // MARK: - Negative: non-playing → closed
+
+    func testDoesNotFire_whenComingFromPaused() {
+        // Paused → closed: user explicitly closed; not a natural episode end.
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .paused, to: .closed),
+            playheadSeconds: 2_695,
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNil(signal)
+    }
+
+    // MARK: - Threshold edges
+
+    func testFires_atThresholdBoundary() {
+        // Default threshold = 30s. 30s remaining is exactly on the edge → fire.
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 2_670, // 30s before end
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNotNil(signal)
+    }
+
+    func testDoesNotFire_justOutsideThreshold() {
+        // 31s remaining is just outside default 30s threshold → do not fire.
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 2_669,
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNil(signal)
+    }
+
+    func testThresholdIsTunable() {
+        // With a wider threshold, the previously-rejected case fires.
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 2_400, // 5 minutes from end
+            durationSeconds: 2_700,
+            episode: episode,
+            threshold: 600 // 10 minutes
+        )
+        XCTAssertNotNil(signal)
+    }
+
+    // MARK: - Defensive: bad inputs
+
+    func testDoesNotFire_withZeroDuration() {
+        // Duration unknown / not yet loaded — never fire.
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 0,
+            durationSeconds: 0,
+            episode: episode
+        )
+        XCTAssertNil(signal)
+    }
+
+    func testDoesNotFire_withNegativeRemaining() {
+        // Playhead past duration — should still fire (treated as "at end").
+        let episode = makeEpisode()
+        let signal = EndOfEpisodeDetector.detect(
+            stateTransition: (from: .playing, to: .closed),
+            playheadSeconds: 2_750,
+            durationSeconds: 2_700,
+            episode: episode
+        )
+        XCTAssertNotNil(signal)
+    }
+}


### PR DESCRIPTION
## Summary

Pure detector that observes `PlayerState` transitions and metadata to emit an `EndOfEpisodeSignal(episode:)` when an episode reaches its natural end. Sibling observer of `PlayerState` — does not extend the state machine, does not write watch state, does not build "Up next" UI (that is #21's job). Foundation for #21's auto-play / grace-period flow.

## Changes

- `App/Features/Player/EndOfEpisodeDetector.swift` (new) — `EndOfEpisodeDetector.detect(stateTransition:playheadSeconds:durationSeconds:episode:threshold:)` plus `EndOfEpisodeSignal` and a `PassthroughSubject` hook for #21's consumer.
- `Tests/ButterBarTests/EndOfEpisodeDetectorTests.swift` (new) — 12 cases covering all AC branches.
- `ButterBar.xcodeproj/project.pbxproj` — wires `Packages/MetadataDomain` into the app + test targets and registers the two new files.

## Acceptance criteria (issue #20)

- [x] `App/Features/Player/EndOfEpisodeDetector.swift` exists with the signature `detect(stateTransition:playheadSeconds:durationSeconds:episode:threshold:) -> EndOfEpisodeSignal?`.
- [x] Trigger: `.playing → .closed` AND `episode != nil` AND playhead within `threshold` seconds of asset end (default 30 s, tunable via parameter).
- [x] Pure function; tested deterministically over recorded `(PlayerState, time, metadata)` triples.
- [x] No new states added to `PlayerState`. The detector is a sibling observer.
- [x] Telemetry hook for #21 to subscribe to (`EndOfEpisodeDetector.publisher: PassthroughSubject<EndOfEpisodeSignal, Never>`).
- [x] Tests: detector fires for genuine episode-end; does NOT fire for movies; does NOT fire on user-initiated mid-episode close; does NOT fire on `.error`; does NOT fire on `.playing → .paused`; threshold-edge cases.

Out of scope per issue (and not done here):
- "Up next" UI (#21).
- Marking watch state (Phase 1's CacheManager owns that on the byte-threshold rule).

## Test plan

- [x] `xcodebuild -scheme ButterBar -destination 'platform=macOS' build` — green.
- [x] `xcodebuild -scheme ButterBar -destination 'platform=macOS' test` — 107/107 pass; 12 new `EndOfEpisodeDetectorTests` all pass; existing suites unchanged.

Closes #20. Refs #3.