### PR TITLE
docs(roadmap): record Phase 2 pause after PR #171 close

### DIFF
--- a/docs/v1-roadmap.md
+++ b/docs/v1-roadmap.md
@@ -79,6 +79,8 @@ Every phase follows the same protocol:
 - Cross-session sidecar persistence — explicit v1 limitation per design doc D5.
 - Subtitle offset / styling controls — v1.5+ per spec 07.
 
+**Status (2026-04-17):** design merged (PR #157); foundation #27 merged (PR #161 — `Packages/SubtitleDomain`, 46 tests); app integration (#28/#29/#30/#32) **PAUSED**. PR #171 was closed without merge after `main` diverged mid-flight — PRs #164 (PlayerState foundation), #166 (overlay controls), and #167 (resume prompt) reshaped `PlayerView` / `PlayerViewModel` around `PlayerDomain.PlayerState` and the `PlayerOverlay` / `PlayerScrubBar` chrome, making the branch's player-integration commits stale against the new shape. The subtitle implementation (SubtitleController, SubtitleIngestor, SubtitleOverlay, SubtitleSelectionMenu, SubtitlePreferenceStore, SubtitleErrorBanner + 25 unit tests + 22 snapshot baselines) is preserved on dangling commit `4308cdc`. See epic #4 for the pickup plan.
+
 **Phase 2 done =** #27, #28, #29, #30, #32 closed; #72 closed as duplicate of #28; epic #4 closed; user can drag a `.srt` onto the player, pick a track, and have the preference persisted across launches.
 
 ### Phase 3 — Playback UX (Epic #3)


### PR DESCRIPTION
## Summary

Phase 2 foundation (#27) is merged via PR #161. App integration (#28/#29/#30/#32) was attempted as PR #171 and closed without merge because main diverged significantly mid-flight (PRs #164/#166/#167 reshaped `PlayerView`/`PlayerViewModel` around `PlayerState` + `PlayerOverlay`).

Adds a `Status (2026-04-17)` block to the Phase 2 section of `docs/v1-roadmap.md` so the next session picking up subtitles knows:

1. Foundation is done; design doc and ACs on #28/#29/#30/#32 are still canonical.
2. The subtitle implementation (SubtitleController, SubtitleIngestor, SubtitleOverlay, SubtitleSelectionMenu, SubtitlePreferenceStore, SubtitleErrorBanner + 25 unit tests + 22 snapshot baselines) is preserved on dangling commit `4308cdc`.
3. A fresh session should cherry-pick the new files and rebuild the Player integration against the post-#167 shape — not re-implement from scratch.

Doesn't revise the aspirational "Phase 2 done =" line — that remains the target.

## Test plan

- [x] Docs-only change, no code touched.
- [x] Phase 2 aspirational end-state wording preserved.

Refs #4, #28, #29, #30, #32