### PR TITLE
feat(provider): Jackett Torznab aggregator with TMDb + IMDb lookup (#179)

### DIFF
--- a/App/Features/Provider/DefaultProviderRegistry.swift
+++ b/App/Features/Provider/DefaultProviderRegistry.swift
@@ -1,10 +1,34 @@
 import ProviderDomain
 
 /// Returns the default set of providers registered for use by the pipeline.
-/// The YTS provider handles movies; EZTV handles TV shows.
-/// Both have `.none` auth model — no API key required.
+/// The YTS provider handles movies; EZTV handles TV shows. Both have `.none`
+/// auth model — no API key required.
+///
+/// Jackett is registered only when the user has supplied a non-empty API
+/// key in Settings > Providers (base URL + key read via
+/// `JackettSettingsStore`). Call sites that don't touch the main actor pass
+/// in a pre-loaded `JackettConfig`; the main-actor entry point reads it
+/// from Keychain/UserDefaults automatically.
 enum DefaultProviderRegistry {
+    /// Convenience entry point. Reads Jackett config from
+    /// `JackettSettingsStore` and composes the provider list. Runs wherever
+    /// the app bootstrap initialises the pipeline — both `UserDefaults` and
+    /// Keychain APIs used underneath are thread-safe.
     static func makeProviders() -> [any MediaProvider] {
-        [YTSProvider(), EZTVProvider()]
+        makeProviders(jackettConfig: JackettSettingsStore().loadConfig())
+    }
+
+    /// Pure function used by tests and by the `@MainActor` entry point.
+    /// Takes an already-resolved Jackett config so it can run off the main
+    /// actor.
+    static func makeProviders(jackettConfig: JackettConfig) -> [any MediaProvider] {
+        var providers: [any MediaProvider] = [YTSProvider(), EZTVProvider()]
+        if jackettConfig.isEnabled {
+            providers.append(JackettProvider(
+                baseURL: jackettConfig.baseURL,
+                apiKey: jackettConfig.apiKey
+            ))
+        }
+        return providers
     }
 }

--- a/App/Features/Provider/Providers/JackettProvider.swift
+++ b/App/Features/Provider/Providers/JackettProvider.swift
@@ -1,0 +1,329 @@
+import Foundation
+import ProviderDomain
+import MetadataDomain
+
+/// Searches a user-run [Jackett](https://github.com/Jackett/Jackett) instance
+/// for torrents across whichever indexers the user has configured in Jackett
+/// itself. Jackett exposes a unified Torznab endpoint; ButterBar delegates all
+/// per-indexer complexity to Jackett and parses the resulting RSS/XML response.
+///
+/// This provider is only registered when the user has entered a non-empty API
+/// key in Settings > Providers — see `DefaultProviderRegistry`.
+///
+/// Category routing: `cat=2000` for movies, `cat=5000` for TV shows, matching
+/// the Torznab category tree.
+struct JackettProvider: MediaProvider {
+    var name: String { "Jackett" }
+    var authModel: ProviderAuthModel { .apiKey(key: apiKey) }
+
+    private let baseURL: URL
+    private let apiKey: String
+    private let session: URLSession
+
+    init(baseURL: URL, apiKey: String, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        self.session = session
+    }
+
+    func search(for item: MediaItem, page _: Int) async throws -> [SourceCandidate] {
+        let query: String
+        let category: String
+        let tmdbID: String?
+        let imdbID: String?
+        switch item {
+        case .movie(let movie):
+            query = movie.title
+            category = "2000"
+            tmdbID = idString(for: movie.id)
+            imdbID = Self.normaliseIMDbID(movie.imdbID)
+        case .show(let show):
+            query = show.name
+            category = "5000"
+            tmdbID = idString(for: show.id)
+            imdbID = Self.normaliseIMDbID(show.imdbID)
+        }
+
+        guard var components = URLComponents(
+            url: baseURL.appendingPathComponent("api/v2.0/indexers/all/results/torznab/api"),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw MediaProviderError.networkError(underlying: JackettURLError.invalidBaseURL as NSError)
+        }
+        // Torznab `t=search` supports metadata-id filters on indexers that
+        // implement them. Passing both `tmdbid` and `imdbid` lets ButterBar
+        // benefit from the most accurate match an indexer can offer without
+        // giving up free-text fallback for indexers that ignore the IDs.
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "t", value: "search"),
+            URLQueryItem(name: "apikey", value: apiKey),
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "cat", value: category),
+        ]
+        if let tmdbID { queryItems.append(URLQueryItem(name: "tmdbid", value: tmdbID)) }
+        if let imdbID { queryItems.append(URLQueryItem(name: "imdbid", value: imdbID)) }
+        components.queryItems = queryItems
+        guard let url = components.url else {
+            throw MediaProviderError.networkError(underlying: JackettURLError.invalidBaseURL as NSError)
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(from: url)
+        } catch {
+            throw MediaProviderError.networkError(underlying: error as NSError)
+        }
+
+        if let http = response as? HTTPURLResponse {
+            switch http.statusCode {
+            case 200..<300: break
+            case 401, 403: throw MediaProviderError.authRequired
+            case 429: throw MediaProviderError.rateLimited
+            default:
+                throw MediaProviderError.networkError(
+                    underlying: JackettURLError.httpStatus(http.statusCode) as NSError
+                )
+            }
+        }
+
+        let items = TorznabXMLParser.parse(data: data)
+        return items.compactMap { item -> SourceCandidate? in
+            let hash = infoHash(from: item)
+            guard !hash.isEmpty || item.magnetURI != nil || item.link != nil else {
+                return nil
+            }
+            let effectiveHash = hash.isEmpty ? fallbackIdentifier(for: item) : hash
+            let torrentURL: URL? = {
+                guard item.magnetURI == nil, let link = item.link else { return nil }
+                return URL(string: link)
+            }()
+            return SourceCandidate(
+                id: "jackett:\(effectiveHash)",
+                infoHash: effectiveHash,
+                magnetURI: item.magnetURI,
+                torrentURL: torrentURL,
+                title: item.title,
+                quality: parseQuality(from: item.title),
+                seeders: item.seeders ?? 0,
+                leechers: item.leechers ?? 0,
+                sizeBytes: item.sizeBytes,
+                providerName: name
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Produce the TMDb numeric ID as a string. Returns `nil` when the
+    /// MediaID provider isn't TMDb (reserved for v1.5+ identity providers).
+    private func idString(for mediaID: MediaID) -> String? {
+        guard mediaID.provider == .tmdb else { return nil }
+        return String(mediaID.id)
+    }
+
+    /// Torznab expects IMDb IDs without the `tt` prefix. Accepts both forms
+    /// and returns the 7-or-more-digit numeric portion, or `nil` when the
+    /// input isn't a recognisable IMDb ID.
+    static func normaliseIMDbID(_ raw: String?) -> String? {
+        guard var s = raw?.trimmingCharacters(in: .whitespaces), !s.isEmpty else { return nil }
+        if s.lowercased().hasPrefix("tt") {
+            s = String(s.dropFirst(2))
+        }
+        return s.allSatisfy(\.isNumber) && !s.isEmpty ? s : nil
+    }
+
+    /// Extracts the 40-char hex info hash from either the explicit `infohash`
+    /// torznab attr or by parsing the magnet URI's `xt=urn:btih:` parameter.
+    private func infoHash(from item: TorznabItem) -> String {
+        if let explicit = item.infoHash, !explicit.isEmpty {
+            return explicit.lowercased()
+        }
+        if let magnet = item.magnetURI, let hash = Self.parseBTIH(from: magnet) {
+            return hash.lowercased()
+        }
+        return ""
+    }
+
+    /// Stable identifier when Jackett returned a torrent file URL without an
+    /// info hash — GUID falls back to the link string hash.
+    private func fallbackIdentifier(for item: TorznabItem) -> String {
+        if let guid = item.guid, !guid.isEmpty { return guid }
+        if let link = item.link, !link.isEmpty { return link }
+        return item.title
+    }
+
+    private static func parseBTIH(from magnet: String) -> String? {
+        guard let components = URLComponents(string: magnet) else { return nil }
+        for qi in components.queryItems ?? [] where qi.name == "xt" {
+            if let value = qi.value, value.lowercased().hasPrefix("urn:btih:") {
+                return String(value.dropFirst("urn:btih:".count))
+            }
+        }
+        return nil
+    }
+
+    private func parseQuality(from title: String) -> SourceQuality {
+        let t = title.uppercased()
+        if t.contains("2160P") || t.contains("4K") { return .remux }
+        if t.contains("1080P") { return .bluRay }
+        if t.contains("720P") { return .webDL }
+        if t.contains("DVDRIP") || t.contains("480P") { return .dvdRip }
+        if t.contains("HDTS") || t.contains(" TS ") || t.hasSuffix(" TS") || t.contains(".TS.") { return .ts }
+        if t.contains("CAM") { return .cam }
+        return .unknown
+    }
+}
+
+// MARK: - Local errors
+
+enum JackettURLError: Error {
+    case invalidBaseURL
+    case httpStatus(Int)
+}
+
+// MARK: - Torznab parser
+
+/// Minimal Torznab RSS parser. Extracts the fields ButterBar ranks on —
+/// title, link/magnet, seeders/leechers, size, info hash — and ignores
+/// everything else. Implemented with the stock `XMLParser` (no third-party
+/// dependency).
+struct TorznabItem: Equatable {
+    var title: String = ""
+    var link: String?
+    var guid: String?
+    var magnetURI: String?
+    var seeders: Int?
+    var leechers: Int?
+    var sizeBytes: Int64?
+    var infoHash: String?
+}
+
+enum TorznabXMLParser {
+    static func parse(data: Data) -> [TorznabItem] {
+        let delegate = TorznabParserDelegate()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        parser.shouldProcessNamespaces = false
+        parser.parse()
+        return delegate.items
+    }
+}
+
+private final class TorznabParserDelegate: NSObject, XMLParserDelegate {
+    var items: [TorznabItem] = []
+    private var currentItem: TorznabItem?
+    private var currentElement: String?
+    private var currentText: String = ""
+
+    func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes attrs: [String: String] = [:]
+    ) {
+        currentElement = elementName
+        currentText = ""
+
+        if elementName == "item" {
+            currentItem = TorznabItem()
+            return
+        }
+
+        guard currentItem != nil else { return }
+
+        // Torznab extended attributes ride on <torznab:attr name="..." value="..."/>
+        // (and occasionally <newznab:attr> — same shape). Namespaces are stripped
+        // because shouldProcessNamespaces is off, so both arrive as "attr".
+        if elementName == "torznab:attr" || elementName == "newznab:attr" || elementName == "attr" {
+            guard let name = attrs["name"]?.lowercased(), let value = attrs["value"] else { return }
+            applyAttr(name: name, value: value)
+            return
+        }
+
+        // <enclosure url="..." length="..."/> — preferred torrent/magnet URL.
+        if elementName == "enclosure" {
+            if let url = attrs["url"], currentItem?.magnetURI == nil, currentItem?.link == nil {
+                if url.lowercased().hasPrefix("magnet:") {
+                    currentItem?.magnetURI = url
+                } else {
+                    currentItem?.link = url
+                }
+            }
+            if currentItem?.sizeBytes == nil, let len = attrs["length"], let size = Int64(len) {
+                currentItem?.sizeBytes = size
+            }
+        }
+    }
+
+    func parser(_: XMLParser, foundCharacters string: String) {
+        currentText += string
+    }
+
+    func parser(_: XMLParser, foundCDATA CDATABlock: Data) {
+        if let s = String(data: CDATABlock, encoding: .utf8) {
+            currentText += s
+        }
+    }
+
+    func parser(
+        _: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?
+    ) {
+        defer { currentElement = nil; currentText = "" }
+        guard var item = currentItem else { return }
+        let trimmed = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch elementName {
+        case "item":
+            items.append(item)
+            currentItem = nil
+            return
+        case "title":
+            if item.title.isEmpty { item.title = trimmed }
+        case "link":
+            if item.link == nil, !trimmed.isEmpty {
+                if trimmed.lowercased().hasPrefix("magnet:") {
+                    item.magnetURI = item.magnetURI ?? trimmed
+                } else {
+                    item.link = trimmed
+                }
+            }
+        case "guid":
+            if item.guid == nil, !trimmed.isEmpty { item.guid = trimmed }
+        case "size":
+            if item.sizeBytes == nil, let s = Int64(trimmed) { item.sizeBytes = s }
+        default:
+            break
+        }
+
+        currentItem = item
+    }
+
+    private func applyAttr(name: String, value: String) {
+        guard var item = currentItem else { return }
+        switch name {
+        case "seeders":
+            item.seeders = Int(value) ?? item.seeders
+        case "peers", "leechers":
+            // Torznab exposes peers (total) on some indexers and leechers on
+            // others. Treat both as the leecher count — SourceCandidate needs
+            // leechers, not the combined figure.
+            item.leechers = Int(value) ?? item.leechers
+        case "size":
+            item.sizeBytes = Int64(value) ?? item.sizeBytes
+        case "infohash":
+            item.infoHash = value
+        case "magneturl":
+            if item.magnetURI == nil { item.magnetURI = value }
+        case "downloadvolumefactor", "uploadvolumefactor", "category":
+            break
+        default:
+            break
+        }
+        currentItem = item
+    }
+}

--- a/App/Features/Provider/Providers/JackettSettingsStore.swift
+++ b/App/Features/Provider/Providers/JackettSettingsStore.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Security
+
+// MARK: - JackettConfig
+
+/// Snapshot of the user's Jackett provider configuration. Produced by
+/// `JackettSettingsStore` at provider-registry build time.
+///
+/// `apiKey` is empty when the user hasn't entered one — callers should treat
+/// an empty key as "provider disabled" and skip registration.
+struct JackettConfig: Equatable {
+    var baseURL: URL
+    var apiKey: String
+
+    static let defaultBaseURL: URL = URL(string: "http://localhost:9117")!
+    static let empty = JackettConfig(baseURL: Self.defaultBaseURL, apiKey: "")
+
+    var isEnabled: Bool { !apiKey.isEmpty }
+}
+
+// MARK: - JackettSettingsStore
+
+/// Read/write access to the user's Jackett base URL (UserDefaults) and API
+/// key (Keychain). Kept separate from any UI type so provider-registry code
+/// can read without importing SwiftUI.
+///
+/// Not `@MainActor`: both `UserDefaults` and the `SecItem*` Keychain APIs are
+/// thread-safe, and the provider registry needs to read the config during
+/// property-initialiser expressions that aren't guaranteed to run on the main
+/// actor.
+final class JackettSettingsStore {
+
+    static let baseURLDefaultsKey = "providers.jackett.baseURL"
+    static let keychainService = "ButterBar.Jackett"
+    static let keychainAccount = "apiKey"
+
+    private let defaults: UserDefaults
+    private let keychain: any KeychainAccess
+
+    init(defaults: UserDefaults = .standard, keychain: (any KeychainAccess)? = nil) {
+        self.defaults = defaults
+        self.keychain = keychain ?? SystemKeychain(
+            service: Self.keychainService,
+            account: Self.keychainAccount
+        )
+    }
+
+    /// Returns the stored base URL or the documented default
+    /// (`http://localhost:9117`) when none has been set.
+    func loadBaseURL() -> URL {
+        if let raw = defaults.string(forKey: Self.baseURLDefaultsKey),
+           let url = URL(string: raw) {
+            return url
+        }
+        return JackettConfig.defaultBaseURL
+    }
+
+    func saveBaseURL(_ url: URL) {
+        defaults.set(url.absoluteString, forKey: Self.baseURLDefaultsKey)
+    }
+
+    /// Returns the stored API key, or the empty string when none is set or
+    /// the Keychain lookup fails.
+    func loadAPIKey() -> String {
+        (try? keychain.read()) ?? ""
+    }
+
+    /// Persists the API key to the Keychain. Passing the empty string removes
+    /// the item rather than storing a zero-length secret.
+    func saveAPIKey(_ key: String) throws {
+        if key.isEmpty {
+            try keychain.delete()
+        } else {
+            try keychain.write(key)
+        }
+    }
+
+    /// Composite load used by `DefaultProviderRegistry` at registry build
+    /// time. Reads URL + API key in a single call.
+    func loadConfig() -> JackettConfig {
+        JackettConfig(baseURL: loadBaseURL(), apiKey: loadAPIKey())
+    }
+}
+
+// MARK: - KeychainAccess
+
+/// Narrow Keychain abstraction so tests can inject a fake without touching
+/// the real `SecItem*` APIs.
+protocol KeychainAccess: Sendable {
+    func read() throws -> String?
+    func write(_ value: String) throws
+    func delete() throws
+}
+
+/// Real `SecItem`-backed keychain store. Uses `kSecClassGenericPassword` with
+/// the service/account pair supplied at init.
+struct SystemKeychain: KeychainAccess {
+    let service: String
+    let account: String
+
+    func read() throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data, let s = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return s
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.osStatus(status)
+        }
+    }
+
+    func write(_ value: String) throws {
+        let data = Data(value.utf8)
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let attributes: [String: Any] = [kSecValueData as String: data]
+
+        let updateStatus = SecItemUpdate(baseQuery as CFDictionary, attributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var insert = baseQuery
+            insert[kSecValueData as String] = data
+            let addStatus = SecItemAdd(insert as CFDictionary, nil)
+            guard addStatus == errSecSuccess else { throw KeychainError.osStatus(addStatus) }
+        default:
+            throw KeychainError.osStatus(updateStatus)
+        }
+    }
+
+    func delete() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        switch status {
+        case errSecSuccess, errSecItemNotFound:
+            return
+        default:
+            throw KeychainError.osStatus(status)
+        }
+    }
+}
+
+enum KeychainError: Error, Equatable {
+    case osStatus(OSStatus)
+}

--- a/App/Features/Settings/ProvidersSettingsPane.swift
+++ b/App/Features/Settings/ProvidersSettingsPane.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+// MARK: - Providers pane (issue #179)
+
+/// Settings > Providers.
+///
+/// Currently surfaces only Jackett configuration (base URL + API key +
+/// test-connection). YTS and EZTV require no user-facing config and are
+/// therefore not listed here.
+struct ProvidersSettingsPane: View {
+
+    @StateObject private var viewModel: ProvidersSettingsViewModel
+
+    init(viewModel: ProvidersSettingsViewModel = ProvidersSettingsViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent("Base URL") {
+                    TextField(
+                        "http://localhost:9117",
+                        text: $viewModel.baseURLText
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .disableAutocorrection(true)
+                    .autocorrectionDisabled(true)
+                    .frame(maxWidth: 260)
+                }
+
+                LabeledContent("API key") {
+                    SecureField("Paste your Jackett API key", text: $viewModel.apiKeyText)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 260)
+                }
+
+                LabeledContent("") {
+                    HStack(spacing: 8) {
+                        Button("Save") { viewModel.save() }
+                            .disabled(!viewModel.canSave)
+
+                        Button("Test connection") {
+                            Task { await viewModel.testConnection() }
+                        }
+                        .disabled(!viewModel.canTest)
+
+                        if let status = viewModel.status {
+                            Text(status.message)
+                                .brandCaption()
+                                .foregroundStyle(status.isError ? Color.red : BrandColors.cocoaSoft)
+                        }
+                    }
+                }
+            } header: {
+                Text("Jackett")
+            } footer: {
+                // Voice: direct, explanatory. No exclamation marks (06-brand.md).
+                Text("Jackett is a self-hosted torrent proxy that aggregates indexers via Torznab. Leave the API key empty to disable Jackett entirely.")
+                    .brandCaption()
+                    .foregroundStyle(BrandColors.cocoaSoft)
+            }
+        }
+        .formStyle(.grouped)
+        .background(BrandColors.surfaceBase)
+        .onAppear { viewModel.reload() }
+    }
+}

--- a/App/Features/Settings/ProvidersSettingsViewModel.swift
+++ b/App/Features/Settings/ProvidersSettingsViewModel.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftUI
+
+// MARK: - ProvidersSettingsViewModel
+
+/// View-model for the Jackett section of Settings > Providers.
+///
+/// Reads and writes through `JackettSettingsStore` so persistence (Keychain
+/// for the API key, UserDefaults for the base URL) sits behind a single
+/// testable seam. The `testConnection()` probe hits the Jackett
+/// `/api/v2.0/server/config` endpoint; anything in the 2xx range counts as a
+/// healthy instance.
+@MainActor
+final class ProvidersSettingsViewModel: ObservableObject {
+
+    @Published var baseURLText: String = ""
+    @Published var apiKeyText: String = ""
+    @Published private(set) var status: Status?
+
+    struct Status: Equatable {
+        let message: String
+        let isError: Bool
+    }
+
+    private let store: JackettSettingsStore
+    private let session: URLSession
+
+    init(
+        store: JackettSettingsStore = JackettSettingsStore(),
+        session: URLSession = .shared
+    ) {
+        self.store = store
+        self.session = session
+    }
+
+    func reload() {
+        baseURLText = store.loadBaseURL().absoluteString
+        apiKeyText = store.loadAPIKey()
+    }
+
+    var canSave: Bool {
+        URL(string: baseURLText) != nil
+    }
+
+    var canTest: Bool {
+        canSave && !apiKeyText.isEmpty
+    }
+
+    func save() {
+        guard let url = URL(string: baseURLText) else {
+            status = Status(message: "That doesn’t look like a URL.", isError: true)
+            return
+        }
+        store.saveBaseURL(url)
+        do {
+            try store.saveAPIKey(apiKeyText)
+            status = Status(message: "Saved.", isError: false)
+        } catch {
+            status = Status(
+                message: "Couldn’t save the API key to your Keychain.",
+                isError: true
+            )
+        }
+    }
+
+    func testConnection() async {
+        guard let base = URL(string: baseURLText) else {
+            status = Status(message: "That doesn’t look like a URL.", isError: true)
+            return
+        }
+        guard !apiKeyText.isEmpty else {
+            status = Status(message: "Enter an API key first.", isError: true)
+            return
+        }
+
+        let url = Self.configProbeURL(base: base, apiKey: apiKeyText)
+        status = Status(message: "Testing…", isError: false)
+        do {
+            let (_, response) = try await session.data(from: url)
+            if let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) {
+                status = Status(message: "Connected.", isError: false)
+            } else if let http = response as? HTTPURLResponse, http.statusCode == 401 || http.statusCode == 403 {
+                status = Status(message: "Jackett rejected the API key.", isError: true)
+            } else {
+                status = Status(message: "Jackett responded with an unexpected status.", isError: true)
+            }
+        } catch {
+            status = Status(message: "Couldn’t reach Jackett.", isError: true)
+        }
+    }
+
+    /// Build the `server/config` probe URL — extracted as a static helper so
+    /// tests can assert the exact shape.
+    static func configProbeURL(base: URL, apiKey: String) -> URL {
+        var components = URLComponents(
+            url: base.appendingPathComponent("api/v2.0/server/config"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [URLQueryItem(name: "apikey", value: apiKey)]
+        return components.url!
+    }
+}

--- a/App/Features/Settings/SettingsView.swift
+++ b/App/Features/Settings/SettingsView.swift
@@ -66,16 +66,6 @@ private struct AccountSettingsPane: View {
     }
 }
 
-private struct ProvidersSettingsPane: View {
-    var body: some View {
-        SettingsPlaceholder(
-            icon: "server.rack",
-            title: "Providers",
-            subtitle: "Configure and prioritise torrent providers here."
-        )
-    }
-}
-
 private struct PlaybackSettingsPane: View {
     var body: some View {
         SettingsPlaceholder(

--- a/ButterBar.xcodeproj/project.pbxproj
+++ b/ButterBar.xcodeproj/project.pbxproj
@@ -156,6 +156,13 @@
 		YTST0001000000000000AA01 /* YTSProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = YTST0001000000000000BB01 /* YTSProviderTests.swift */; };
 		EZTV0002000000000000AA01 /* EZTVProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EZTV0002000000000000BB01 /* EZTVProviderTests.swift */; };
 		MOCK0001000000000000AA01 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOCK0001000000000000BB01 /* MockURLSession.swift */; };
+		JCKT0001000000000000AA01 /* JackettProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = JCKT0001000000000000BB01 /* JackettProvider.swift */; };
+		JCKT0002000000000000AA01 /* JackettSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = JCKT0002000000000000BB01 /* JackettSettingsStore.swift */; };
+		JCKT0003000000000000AA01 /* ProvidersSettingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = JCKT0003000000000000BB01 /* ProvidersSettingsPane.swift */; };
+		JCKT0004000000000000AA01 /* ProvidersSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = JCKT0004000000000000BB01 /* ProvidersSettingsViewModel.swift */; };
+		JCKT0005000000000000AA01 /* JackettProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = JCKT0005000000000000BB01 /* JackettProviderTests.swift */; };
+		JCKT0006000000000000AA01 /* JackettSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = JCKT0006000000000000BB01 /* JackettSettingsStoreTests.swift */; };
+		JCKT0007000000000000AA01 /* DefaultProviderRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = JCKT0007000000000000BB01 /* DefaultProviderRegistryTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -340,6 +347,13 @@
 		YTST0001000000000000BB01 /* YTSProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YTSProviderTests.swift; sourceTree = "<group>"; };
 		EZTV0002000000000000BB01 /* EZTVProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EZTVProviderTests.swift; sourceTree = "<group>"; };
 		MOCK0001000000000000BB01 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		JCKT0001000000000000BB01 /* JackettProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JackettProvider.swift; sourceTree = "<group>"; };
+		JCKT0002000000000000BB01 /* JackettSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JackettSettingsStore.swift; sourceTree = "<group>"; };
+		JCKT0003000000000000BB01 /* ProvidersSettingsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersSettingsPane.swift; sourceTree = "<group>"; };
+		JCKT0004000000000000BB01 /* ProvidersSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersSettingsViewModel.swift; sourceTree = "<group>"; };
+		JCKT0005000000000000BB01 /* JackettProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JackettProviderTests.swift; sourceTree = "<group>"; };
+		JCKT0006000000000000BB01 /* JackettSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JackettSettingsStoreTests.swift; sourceTree = "<group>"; };
+		JCKT0007000000000000BB01 /* DefaultProviderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProviderRegistryTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -462,6 +476,9 @@
 				SD000012000000000000BB01 /* SubtitleErrorBannerSnapshotTests.swift */,
 				YTST0001000000000000BB01 /* YTSProviderTests.swift */,
 				EZTV0002000000000000BB01 /* EZTVProviderTests.swift */,
+				JCKT0005000000000000BB01 /* JackettProviderTests.swift */,
+				JCKT0006000000000000BB01 /* JackettSettingsStoreTests.swift */,
+				JCKT0007000000000000BB01 /* DefaultProviderRegistryTests.swift */,
 				SUPP0001000000000000GG01 /* Support */,
 			);
 			path = ButterBarTests;
@@ -493,6 +510,8 @@
 			children = (
 				SETV0001000000000000BB01 /* SettingsView.swift */,
 				SETV0002000000000000BB01 /* StorageSettingsPane.swift */,
+				JCKT0003000000000000BB01 /* ProvidersSettingsPane.swift */,
+				JCKT0004000000000000BB01 /* ProvidersSettingsViewModel.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -512,6 +531,8 @@
 			children = (
 				YTSP0001000000000000BB01 /* YTSProvider.swift */,
 				EZTV0001000000000000BB01 /* EZTVProvider.swift */,
+				JCKT0001000000000000BB01 /* JackettProvider.swift */,
+				JCKT0002000000000000BB01 /* JackettSettingsStore.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -925,6 +946,9 @@
 				SD000012000000000000AA01 /* SubtitleErrorBannerSnapshotTests.swift in Sources */,
 				YTST0001000000000000AA01 /* YTSProviderTests.swift in Sources */,
 				EZTV0002000000000000AA01 /* EZTVProviderTests.swift in Sources */,
+				JCKT0005000000000000AA01 /* JackettProviderTests.swift in Sources */,
+				JCKT0006000000000000AA01 /* JackettSettingsStoreTests.swift in Sources */,
+				JCKT0007000000000000AA01 /* DefaultProviderRegistryTests.swift in Sources */,
 				MOCK0001000000000000AA01 /* MockURLSession.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1029,6 +1053,10 @@
 				DREG0001000000000000AA01 /* DefaultProviderRegistry.swift in Sources */,
 				YTSP0001000000000000AA01 /* YTSProvider.swift in Sources */,
 				EZTV0001000000000000AA01 /* EZTVProvider.swift in Sources */,
+				JCKT0001000000000000AA01 /* JackettProvider.swift in Sources */,
+				JCKT0002000000000000AA01 /* JackettSettingsStore.swift in Sources */,
+				JCKT0003000000000000AA01 /* ProvidersSettingsPane.swift in Sources */,
+				JCKT0004000000000000AA01 /* ProvidersSettingsViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Packages/MetadataDomain/Sources/MetadataDomain/Movie.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/Movie.swift
@@ -15,6 +15,12 @@ public struct Movie: Equatable, Sendable, Hashable, Codable {
     public let voteAverage: Double?
     public let popularity: Double?
     public let cast: [CastMember]
+    /// IMDb identifier in canonical `tt0133093` form. Populated by the
+    /// metadata provider when detail is fetched; `nil` for browse-row
+    /// projections that only carry TMDb summary data. Consumed by external
+    /// provider integrations (e.g. Jackett/Torznab) that support
+    /// `imdbid` lookups in addition to `tmdbid`.
+    public let imdbID: String?
 
     public init(id: MediaID,
                 title: String,
@@ -27,7 +33,8 @@ public struct Movie: Equatable, Sendable, Hashable, Codable {
                 backdropPath: String?,
                 voteAverage: Double?,
                 popularity: Double?,
-                cast: [CastMember] = []) {
+                cast: [CastMember] = [],
+                imdbID: String? = nil) {
         self.id = id
         self.title = title
         self.originalTitle = originalTitle
@@ -40,11 +47,12 @@ public struct Movie: Equatable, Sendable, Hashable, Codable {
         self.voteAverage = voteAverage
         self.popularity = popularity
         self.cast = cast
+        self.imdbID = imdbID
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, title, originalTitle, releaseYear, runtimeMinutes, overview
-        case genres, posterPath, backdropPath, voteAverage, popularity, cast
+        case genres, posterPath, backdropPath, voteAverage, popularity, cast, imdbID
     }
 
     public init(from decoder: Decoder) throws {
@@ -61,5 +69,6 @@ public struct Movie: Equatable, Sendable, Hashable, Codable {
         voteAverage = try container.decodeIfPresent(Double.self, forKey: .voteAverage)
         popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)
         cast = try container.decodeIfPresent([CastMember].self, forKey: .cast) ?? []
+        imdbID = try container.decodeIfPresent(String.self, forKey: .imdbID)
     }
 }

--- a/Packages/MetadataDomain/Sources/MetadataDomain/Show.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/Show.swift
@@ -16,6 +16,11 @@ public struct Show: Equatable, Sendable, Hashable, Codable {
     /// Hydrated lazily by the detail fetch; can be empty for browse-row results.
     public let seasons: [Season]
     public let cast: [CastMember]
+    /// IMDb identifier in canonical `tt0903747` form. Populated from TMDb
+    /// external IDs when detail is fetched; `nil` for browse-row projections.
+    /// Consumed by external provider integrations (e.g. Jackett/Torznab) that
+    /// support `imdbid` lookups in addition to `tmdbid`.
+    public let imdbID: String?
 
     public init(id: MediaID,
                 name: String,
@@ -30,7 +35,8 @@ public struct Show: Equatable, Sendable, Hashable, Codable {
                 voteAverage: Double?,
                 popularity: Double?,
                 seasons: [Season],
-                cast: [CastMember] = []) {
+                cast: [CastMember] = [],
+                imdbID: String? = nil) {
         self.id = id
         self.name = name
         self.originalName = originalName
@@ -45,12 +51,13 @@ public struct Show: Equatable, Sendable, Hashable, Codable {
         self.popularity = popularity
         self.seasons = seasons
         self.cast = cast
+        self.imdbID = imdbID
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, name, originalName, firstAirYear, lastAirYear, status
         case overview, genres, posterPath, backdropPath, voteAverage
-        case popularity, seasons, cast
+        case popularity, seasons, cast, imdbID
     }
 
     public init(from decoder: Decoder) throws {
@@ -69,5 +76,6 @@ public struct Show: Equatable, Sendable, Hashable, Codable {
         popularity = try container.decodeIfPresent(Double.self, forKey: .popularity)
         seasons = try container.decode([Season].self, forKey: .seasons)
         cast = try container.decodeIfPresent([CastMember].self, forKey: .cast) ?? []
+        imdbID = try container.decodeIfPresent(String.self, forKey: .imdbID)
     }
 }

--- a/Packages/MetadataDomain/Sources/MetadataDomain/TMDBProvider.swift
+++ b/Packages/MetadataDomain/Sources/MetadataDomain/TMDBProvider.swift
@@ -107,8 +107,10 @@ public actor TMDBProvider: MetadataProvider {
 
     public func showDetail(id: MediaID) async throws -> Show {
         precondition(id.provider == .tmdb)
+        // external_ids is appended so `imdb_id` is available downstream for
+        // Jackett/Torznab integrations that search by IMDb ID.
         let url = appendingQueryItem(
-            URLQueryItem(name: "append_to_response", value: "credits"),
+            URLQueryItem(name: "append_to_response", value: "credits,external_ids"),
             to: endpoint("/tv/\(id.id)")
         )
         let dto: ShowDetailDTO = try await fetch(url: url, ttl: MetadataCacheTTL.showDetail)
@@ -436,6 +438,8 @@ struct MovieDetailDTO: Decodable {
     let popularity: Double?
     let genres: [GenreDTO]?
     let credits: CreditsDTO?
+    /// TMDb movie detail exposes `imdb_id` as a top-level field.
+    let imdbID: String?
 
     private enum CodingKeys: String, CodingKey {
         case id, title, runtime, overview, popularity, genres, credits
@@ -444,12 +448,18 @@ struct MovieDetailDTO: Decodable {
         case posterPath = "poster_path"
         case backdropPath = "backdrop_path"
         case voteAverage = "vote_average"
+        case imdbID = "imdb_id"
     }
 
     func toMovie() -> Movie {
         let year: Int? = {
             guard let r = releaseDate, r.count >= 4 else { return nil }
             return Int(r.prefix(4))
+        }()
+        let cleanedIMDb: String? = {
+            guard let raw = imdbID else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            return trimmed.isEmpty ? nil : trimmed
         }()
         return Movie(
             id: MediaID(provider: .tmdb, id: id),
@@ -463,7 +473,8 @@ struct MovieDetailDTO: Decodable {
             backdropPath: backdropPath,
             voteAverage: voteAverage,
             popularity: popularity,
-            cast: (credits?.cast ?? []).map { $0.toCastMember() }
+            cast: (credits?.cast ?? []).map { $0.toCastMember() },
+            imdbID: cleanedIMDb
         )
     }
 }
@@ -484,6 +495,7 @@ struct ShowDetailDTO: Decodable {
     let genres: [GenreDTO]?
     let seasons: [SeasonSummaryDTO]?
     let credits: CreditsDTO?
+    let externalIDs: ExternalIDsDTO?
 
     private enum CodingKeys: String, CodingKey {
         case id, name, status, overview, popularity, genres, seasons, credits
@@ -494,6 +506,7 @@ struct ShowDetailDTO: Decodable {
         case posterPath = "poster_path"
         case backdropPath = "backdrop_path"
         case voteAverage = "vote_average"
+        case externalIDs = "external_ids"
     }
 
     func toShow() -> Show {
@@ -525,6 +538,11 @@ struct ShowDetailDTO: Decodable {
                    airDate: nil,
                    episodes: [])
         }
+        let cleanedIMDb: String? = {
+            guard let raw = externalIDs?.imdbID else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            return trimmed.isEmpty ? nil : trimmed
+        }()
         return Show(
             id: showID,
             name: name,
@@ -539,8 +557,19 @@ struct ShowDetailDTO: Decodable {
             voteAverage: voteAverage,
             popularity: popularity,
             seasons: mappedSeasons,
-            cast: (credits?.cast ?? []).map { $0.toCastMember() }
+            cast: (credits?.cast ?? []).map { $0.toCastMember() },
+            imdbID: cleanedIMDb
         )
+    }
+}
+
+/// Subset of TMDb `external_ids` append response. Only `imdb_id` is consumed
+/// today; other IDs (tvdb, freebase) are ignored.
+struct ExternalIDsDTO: Decodable {
+    let imdbID: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case imdbID = "imdb_id"
     }
 }
 

--- a/Tests/ButterBarTests/DefaultProviderRegistryTests.swift
+++ b/Tests/ButterBarTests/DefaultProviderRegistryTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import ProviderDomain
+@testable import ButterBar
+
+final class DefaultProviderRegistryTests: XCTestCase {
+
+    // MARK: - testRegistry_withoutJackettKey_onlyRegistersBuiltIns
+
+    func testRegistry_withoutJackettKey_onlyRegistersBuiltIns() {
+        let providers = DefaultProviderRegistry.makeProviders(
+            jackettConfig: JackettConfig(
+                baseURL: JackettConfig.defaultBaseURL,
+                apiKey: ""
+            )
+        )
+        let names = providers.map(\.name)
+        XCTAssertEqual(names, ["YTS", "EZTV"])
+    }
+
+    // MARK: - testRegistry_withJackettKey_appendsJackett
+
+    func testRegistry_withJackettKey_appendsJackett() {
+        let providers = DefaultProviderRegistry.makeProviders(
+            jackettConfig: JackettConfig(
+                baseURL: URL(string: "http://localhost:9117")!,
+                apiKey: "my-secret"
+            )
+        )
+        let names = providers.map(\.name)
+        XCTAssertEqual(names, ["YTS", "EZTV", "Jackett"])
+
+        // The Jackett provider declares .apiKey auth.
+        guard let jackett = providers.last else { return XCTFail("Jackett missing") }
+        guard case .apiKey(let key) = jackett.authModel else {
+            return XCTFail("Expected .apiKey auth, got \(jackett.authModel)")
+        }
+        XCTAssertEqual(key, "my-secret")
+    }
+
+    // MARK: - testConfigProbeURL_includesApiKey
+
+    @MainActor
+    func testConfigProbeURL_includesApiKey() {
+        let url = ProvidersSettingsViewModel.configProbeURL(
+            base: URL(string: "http://localhost:9117")!,
+            apiKey: "ABC"
+        )
+        XCTAssertEqual(url.absoluteString, "http://localhost:9117/api/v2.0/server/config?apikey=ABC")
+    }
+}

--- a/Tests/ButterBarTests/JackettProviderTests.swift
+++ b/Tests/ButterBarTests/JackettProviderTests.swift
@@ -1,0 +1,324 @@
+import XCTest
+import MetadataDomain
+import ProviderDomain
+@testable import ButterBar
+
+final class JackettProviderTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        RecordingURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        RecordingURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - testSearch_movie_parsesTorznabFixture
+
+    func testSearch_movie_parsesTorznabFixture() async throws {
+        RecordingURLProtocol.responseData = torznabMovieFixture
+        let session = Self.makeSession()
+        let provider = JackettProvider(
+            baseURL: URL(string: "http://localhost:9117")!,
+            apiKey: "secret",
+            session: session
+        )
+
+        let results = try await provider.search(
+            for: .movie(makeMovie(title: "Blade Runner 2049", tmdbID: 335984, imdbID: "tt1856101")),
+            page: 1
+        )
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.allSatisfy { $0.providerName == "Jackett" })
+        XCTAssertTrue(results.allSatisfy { $0.id.hasPrefix("jackett:") })
+
+        // First item: magnet + torznab attrs (seeders, peers, size, infohash).
+        let first = results[0]
+        XCTAssertEqual(first.infoHash, "aaaabbbbccccdddd1111222233334444aaaabbbb")
+        XCTAssertEqual(first.seeders, 123)
+        XCTAssertEqual(first.leechers, 12)
+        XCTAssertEqual(first.sizeBytes, 2_147_483_648)
+        XCTAssertNotNil(first.magnetURI)
+        XCTAssertEqual(first.quality, .bluRay) // "1080p" in title
+
+        // Second item: .torrent URL via enclosure, size parsed from <size>.
+        let second = results[1]
+        XCTAssertNotNil(second.torrentURL)
+        XCTAssertNil(second.magnetURI)
+        XCTAssertEqual(second.quality, .remux) // "2160p" in title
+        XCTAssertEqual(second.sizeBytes, 9_876_543_210)
+    }
+
+    // MARK: - testSearch_movie_usesCategory2000
+
+    func testSearch_movie_usesCategory2000() async throws {
+        RecordingURLProtocol.responseData = emptyRSSFixture
+        let session = Self.makeSession()
+        let provider = JackettProvider(
+            baseURL: URL(string: "http://localhost:9117")!,
+            apiKey: "secret",
+            session: session
+        )
+
+        _ = try await provider.search(
+            for: .movie(makeMovie(title: "Arrival", tmdbID: 329865, imdbID: "tt2543164")),
+            page: 1
+        )
+
+        let last = try XCTUnwrap(RecordingURLProtocol.lastRequestURL)
+        let items = URLComponents(url: last, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.first(where: { $0.name == "cat" })?.value, "2000")
+        XCTAssertEqual(items.first(where: { $0.name == "t" })?.value, "search")
+        XCTAssertEqual(items.first(where: { $0.name == "apikey" })?.value, "secret")
+        XCTAssertEqual(items.first(where: { $0.name == "q" })?.value, "Arrival")
+        // TMDb + IMDb ID should ride along for indexers that support them.
+        XCTAssertEqual(items.first(where: { $0.name == "tmdbid" })?.value, "329865")
+        XCTAssertEqual(items.first(where: { $0.name == "imdbid" })?.value, "2543164")
+    }
+
+    // MARK: - testSearch_show_usesCategory5000AndIDs
+
+    func testSearch_show_usesCategory5000AndIDs() async throws {
+        RecordingURLProtocol.responseData = emptyRSSFixture
+        let session = Self.makeSession()
+        let provider = JackettProvider(
+            baseURL: URL(string: "http://localhost:9117")!,
+            apiKey: "secret",
+            session: session
+        )
+
+        _ = try await provider.search(
+            for: .show(makeShow(name: "Severance", tmdbID: 95396, imdbID: "tt11280740")),
+            page: 1
+        )
+
+        let last = try XCTUnwrap(RecordingURLProtocol.lastRequestURL)
+        let items = URLComponents(url: last, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.first(where: { $0.name == "cat" })?.value, "5000")
+        XCTAssertEqual(items.first(where: { $0.name == "q" })?.value, "Severance")
+        XCTAssertEqual(items.first(where: { $0.name == "tmdbid" })?.value, "95396")
+        XCTAssertEqual(items.first(where: { $0.name == "imdbid" })?.value, "11280740")
+    }
+
+    // MARK: - testSearch_movie_omitsImdbParamWhenUnknown
+
+    func testSearch_movie_omitsImdbParamWhenUnknown() async throws {
+        RecordingURLProtocol.responseData = emptyRSSFixture
+        let session = Self.makeSession()
+        let provider = JackettProvider(
+            baseURL: URL(string: "http://localhost:9117")!,
+            apiKey: "secret",
+            session: session
+        )
+
+        _ = try await provider.search(
+            for: .movie(makeMovie(title: "No Imdb Id", tmdbID: 42, imdbID: nil)),
+            page: 1
+        )
+
+        let last = try XCTUnwrap(RecordingURLProtocol.lastRequestURL)
+        let items = URLComponents(url: last, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.first(where: { $0.name == "tmdbid" })?.value, "42")
+        XCTAssertNil(items.first(where: { $0.name == "imdbid" }))
+    }
+
+    // MARK: - testSearch_offline_surfacesNetworkError
+
+    func testSearch_offline_surfacesNetworkError() async {
+        RecordingURLProtocol.simulatedError = URLError(.cannotConnectToHost)
+        let session = Self.makeSession()
+        let provider = JackettProvider(
+            baseURL: URL(string: "http://localhost:9117")!,
+            apiKey: "secret",
+            session: session
+        )
+
+        do {
+            _ = try await provider.search(
+                for: .movie(makeMovie(title: "Dune", tmdbID: 438631, imdbID: nil)),
+                page: 1
+            )
+            XCTFail("Expected network error")
+        } catch let error as MediaProviderError {
+            guard case .networkError = error else {
+                XCTFail("Expected .networkError, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Expected MediaProviderError, got \(error)")
+        }
+    }
+
+    // MARK: - testSearch_authRejection_surfacesAuthRequired
+
+    func testSearch_authRejection_surfacesAuthRequired() async {
+        RecordingURLProtocol.responseData = Data()
+        RecordingURLProtocol.responseStatusCode = 403
+        let session = Self.makeSession()
+        let provider = JackettProvider(
+            baseURL: URL(string: "http://localhost:9117")!,
+            apiKey: "bad-key",
+            session: session
+        )
+
+        do {
+            _ = try await provider.search(
+                for: .movie(makeMovie(title: "Anything", tmdbID: 1, imdbID: nil)),
+                page: 1
+            )
+            XCTFail("Expected auth error")
+        } catch let error as MediaProviderError {
+            XCTAssertEqual(error.localizedDescription, MediaProviderError.authRequired.localizedDescription)
+        } catch {
+            XCTFail("Expected MediaProviderError, got \(error)")
+        }
+    }
+
+    // MARK: - testNormaliseIMDb_stripsPrefix
+
+    func testNormaliseIMDb_stripsPrefix() {
+        XCTAssertEqual(JackettProvider.normaliseIMDbID("tt1856101"), "1856101")
+        XCTAssertEqual(JackettProvider.normaliseIMDbID("1856101"), "1856101")
+        XCTAssertNil(JackettProvider.normaliseIMDbID(nil))
+        XCTAssertNil(JackettProvider.normaliseIMDbID(""))
+        XCTAssertNil(JackettProvider.normaliseIMDbID("not-an-id"))
+    }
+
+    // MARK: - testTorznabParser_handlesAttrNamespacedAndBare
+
+    func testTorznabParser_handlesAttrNamespacedAndBare() {
+        let items = TorznabXMLParser.parse(data: torznabMovieFixture)
+        XCTAssertEqual(items.count, 2)
+        // Both namespaced and unnamespaced forms land in the same item model.
+        XCTAssertEqual(items[0].seeders, 123)
+        XCTAssertEqual(items[0].infoHash, "aaaabbbbccccdddd1111222233334444aaaabbbb")
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RecordingURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    private func makeMovie(title: String, tmdbID: Int64, imdbID: String?) -> Movie {
+        Movie(
+            id: MediaID(provider: .tmdb, id: tmdbID),
+            title: title,
+            originalTitle: title,
+            releaseYear: 2020,
+            runtimeMinutes: nil,
+            overview: "",
+            genres: [],
+            posterPath: nil,
+            backdropPath: nil,
+            voteAverage: nil,
+            popularity: nil,
+            imdbID: imdbID
+        )
+    }
+
+    private func makeShow(name: String, tmdbID: Int64, imdbID: String?) -> Show {
+        Show(
+            id: MediaID(provider: .tmdb, id: tmdbID),
+            name: name,
+            originalName: name,
+            firstAirYear: 2022,
+            lastAirYear: nil,
+            status: .returning,
+            overview: "",
+            genres: [],
+            posterPath: nil,
+            backdropPath: nil,
+            voteAverage: nil,
+            popularity: nil,
+            seasons: [],
+            imdbID: imdbID
+        )
+    }
+
+    /// Mixed fixture: one item with a magnet + torznab:attr style, one with
+    /// an enclosure pointing at a .torrent and a plain <size> element.
+    private let torznabMovieFixture = Data(#"""
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+      <channel>
+        <title>Jackett</title>
+        <item>
+          <title>Blade Runner 2049 2017 1080p BluRay x264</title>
+          <guid>abc-123</guid>
+          <link>magnet:?xt=urn:btih:aaaabbbbccccdddd1111222233334444aaaabbbb&amp;dn=Blade+Runner</link>
+          <torznab:attr name="seeders" value="123"/>
+          <torznab:attr name="peers" value="12"/>
+          <torznab:attr name="size" value="2147483648"/>
+          <torznab:attr name="infohash" value="aaaabbbbccccdddd1111222233334444aaaabbbb"/>
+        </item>
+        <item>
+          <title>Blade Runner 2049 2017 2160p UHD BluRay REMUX</title>
+          <guid>def-456</guid>
+          <link>https://tracker.example/download/xyz.torrent</link>
+          <enclosure url="https://tracker.example/download/xyz.torrent" length="9876543210" type="application/x-bittorrent"/>
+          <size>9876543210</size>
+          <attr name="seeders" value="45"/>
+          <attr name="leechers" value="8"/>
+        </item>
+      </channel>
+    </rss>
+    """#.utf8)
+
+    private let emptyRSSFixture = Data(#"""
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+      <channel><title>Jackett</title></channel>
+    </rss>
+    """#.utf8)
+}
+
+// MARK: - RecordingURLProtocol
+
+/// Local URL-protocol stub that records the outgoing request URL so
+/// assertions can inspect the query string and can optionally inject a URL
+/// error to simulate an offline Jackett instance. Kept local to the test
+/// file so the shared `MockURLProtocol` remains unchanged.
+final class RecordingURLProtocol: URLProtocol {
+    static var responseData: Data = Data()
+    static var responseStatusCode: Int = 200
+    static var simulatedError: Error?
+    static var lastRequestURL: URL?
+
+    static func reset() {
+        responseData = Data()
+        responseStatusCode = 200
+        simulatedError = nil
+        lastRequestURL = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        RecordingURLProtocol.lastRequestURL = request.url
+
+        if let error = RecordingURLProtocol.simulatedError {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+
+        let url = request.url ?? URL(string: "about:blank")!
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: RecordingURLProtocol.responseStatusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/rss+xml"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: RecordingURLProtocol.responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/ButterBarTests/JackettSettingsStoreTests.swift
+++ b/Tests/ButterBarTests/JackettSettingsStoreTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import ButterBar
+
+final class JackettSettingsStoreTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "JackettSettingsStoreTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - testLoadBaseURL_returnsDefaultWhenUnset
+
+    func testLoadBaseURL_returnsDefaultWhenUnset() {
+        let store = JackettSettingsStore(defaults: defaults, keychain: FakeKeychain())
+        XCTAssertEqual(store.loadBaseURL(), URL(string: "http://localhost:9117")!)
+    }
+
+    // MARK: - testSaveAndLoadBaseURL_roundTrips
+
+    func testSaveAndLoadBaseURL_roundTrips() {
+        let store = JackettSettingsStore(defaults: defaults, keychain: FakeKeychain())
+        let remote = URL(string: "https://jackett.mydomain.tld:9117")!
+        store.saveBaseURL(remote)
+        XCTAssertEqual(store.loadBaseURL(), remote)
+    }
+
+    // MARK: - testSaveAPIKey_emptyDeletes
+
+    func testSaveAPIKey_emptyDeletes() throws {
+        let keychain = FakeKeychain()
+        let store = JackettSettingsStore(defaults: defaults, keychain: keychain)
+
+        try store.saveAPIKey("abc123")
+        XCTAssertEqual(store.loadAPIKey(), "abc123")
+
+        try store.saveAPIKey("")
+        XCTAssertEqual(store.loadAPIKey(), "")
+        XCTAssertTrue(keychain.deleted)
+    }
+
+    // MARK: - testLoadConfig_reflectsPersistedState
+
+    func testLoadConfig_reflectsPersistedState() throws {
+        let keychain = FakeKeychain()
+        let store = JackettSettingsStore(defaults: defaults, keychain: keychain)
+        store.saveBaseURL(URL(string: "http://example:9117")!)
+        try store.saveAPIKey("k")
+
+        let config = store.loadConfig()
+        XCTAssertEqual(config.baseURL, URL(string: "http://example:9117")!)
+        XCTAssertEqual(config.apiKey, "k")
+        XCTAssertTrue(config.isEnabled)
+    }
+
+    // MARK: - testLoadConfig_emptyKeyIsDisabled
+
+    func testLoadConfig_emptyKeyIsDisabled() {
+        let store = JackettSettingsStore(defaults: defaults, keychain: FakeKeychain())
+        let config = store.loadConfig()
+        XCTAssertFalse(config.isEnabled)
+    }
+}
+
+// MARK: - FakeKeychain
+
+private final class FakeKeychain: KeychainAccess, @unchecked Sendable {
+    private var stored: String?
+    private(set) var deleted: Bool = false
+
+    func read() throws -> String? { stored }
+
+    func write(_ value: String) throws {
+        stored = value
+        deleted = false
+    }
+
+    func delete() throws {
+        stored = nil
+        deleted = true
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `JackettProvider` that talks to a user-run Jackett instance via the unified Torznab RSS API. Once the user enters a base URL + API key in Settings > Providers, ButterBar fans out search requests to every indexer the user has configured inside Jackett itself — no per-indexer scraping code, no indexer credentials stored in ButterBar, no new surface area for any specific site.

Per the follow-up instruction, the provider links queries to **both TMDb and IMDb** metadata IDs where available. Each Torznab search includes `tmdbid=…` (always, since every `MediaID` currently originates from TMDb) and `imdbid=…` (when populated from TMDb detail fetches). Indexers that support ID-based matching get a precise result set; indexers that ignore them still benefit from the free-text `q=` fallback.

Closes #179

## Why this fits ButterBar

- Users on the home-server/NAS stack get their whole Jackett indexer set immediately.
- ButterBar stays clean: no per-indexer code paths, no new legal surface.
- Completely optional: providers are registered only when a non-empty API key is present, so users without Jackett see no UI change beyond the empty Providers form.

## Changes

**Provider**
- `JackettProvider` (`.apiKey` auth, `cat=2000` for movies, `cat=5000` for shows).
- `TorznabXMLParser` built on stock `XMLParser` — no third-party XML dependency. Reads `<title>`, `<link>`, `<enclosure>`, `<torznab:attr>` (seeders, peers, size, infohash), and plain `<size>` fallback.
- HTTP status handling maps 401/403 → `.authRequired`, 429 → `.rateLimited`, transport errors → `.networkError`, so the pipeline's per-provider error slot is used consistently.
- Quality parsed from the release title, same rules as `EZTVProvider` (per spec).

**TMDb + IMDb linking**
- `JackettProvider.search` adds `tmdbid=<MediaID.id>` and, when known, `imdbid=<normalised-id>` to the Torznab query.
- `Movie` and `Show` gain an optional `imdbID: String?` (backward compatible — defaults to `nil`, existing init sites and Codable round-trips unaffected).
- `TMDBProvider.movieDetail` already receives `imdb_id` at the top level; added it to `MovieDetailDTO` and plumbed it into `Movie`.
- `TMDBProvider.showDetail` now appends `external_ids` (`append_to_response=credits,external_ids`) and reads `imdb_id` into `Show`.

**Settings**
- `JackettSettingsStore` persists the base URL in `UserDefaults` and the API key in the Keychain via a `KeychainAccess` seam (real `SecItem` impl + fake for tests). Not `@MainActor` because the underlying APIs are thread-safe and the registry reads the config during property-initialiser expressions.
- `ProvidersSettingsPane` replaces the old placeholder: base URL field, secure API-key field, Save button, and a "Test connection" button that hits `/api/v2.0/server/config`.

**Registry**
- `DefaultProviderRegistry.makeProviders()` is unchanged from the caller's perspective; the `JackettProvider` is appended only when `JackettConfig.isEnabled` (non-empty API key).

**Tests**
- `JackettProviderTests`: fixture parsing (magnet + `<enclosure>` paths), `cat=2000`/`cat=5000` routing, `tmdbid` + `imdbid` present, `imdbid` omitted when unknown, offline `networkError`, 403 `authRequired`, IMDb ID normalisation, Torznab namespaced + bare `<attr>` handling.
- `JackettSettingsStoreTests`: round-trip + empty-key deletes Keychain item.
- `DefaultProviderRegistryTests`: gating behaviour + probe URL shape.

## Test plan

- [x] Unit tests added for parser, category routing, ID plumbing, offline/auth paths, registry gating, settings store.
- [ ] Manual: run a local Jackett, enter URL + key, hit Test connection, run a search for a known title, confirm `tmdbid`/`imdbid` appear in Jackett's request log.

## Out of scope

- ATS exceptions for `http://localhost` — deferred to a deployment-config change if manual testing shows sandboxed builds block it.
- Prowlarr (Jackett's successor) — can be added as a follow-on, same Torznab parser.
- Flaresolverr / CAPTCHA bypass.
- Per-indexer configuration inside Jackett (users manage that in Jackett's own UI).

https://claude.ai/code/session_01KeYQpeyh6siKy9u9tuy6jR